### PR TITLE
fix(docs): Correct HTML tag in model removal list for consistency

### DIFF
--- a/apps/docs/blog/2025-05-05-deni-ai-v3.2.1.md
+++ b/apps/docs/blog/2025-05-05-deni-ai-v3.2.1.md
@@ -20,7 +20,7 @@ We've made several improvements to model selection. Here are the highlights:
 - **Models to be Removed**: Some models (listed below) are old or unstable and will be removed on 5/10.
 
 **Models to be Removed**:
-> Google: Gemini 2.0 Flash Lite, Gemini 1.5 Pro <br>
+> Google: Gemini 2.0 Flash Lite, Gemini 1.5 Pro <br />
 > Grok: Grok 3 Beta / 3 mini Beta (OpenRouter)
 
 ## Conversation Search

--- a/apps/docs/i18n/ja/docusaurus-plugin-content-blog/2025-05-05-deni-ai-v3.2.1.md
+++ b/apps/docs/i18n/ja/docusaurus-plugin-content-blog/2025-05-05-deni-ai-v3.2.1.md
@@ -20,7 +20,7 @@ tags: [update]
 - **削除されるモデル**: 一部のモデル (下部に一覧) は古い、または不安定のため、5/10 に削除されます。
 
 **削除されるモデル**:
-> Google: Gemini 2.0 Flash Lite, Gemini 1.5 Pro <br>
+> Google: Gemini 2.0 Flash Lite, Gemini 1.5 Pro <br />
 > Grok: Grok 3 Beta / 3 mini Beta (OpenRouter)
 
 ## 会話の検索


### PR DESCRIPTION
- Updated the HTML line break tag from `<br>` to `<br />` in the model removal section of the Deni AI v3.2.1 release notes for both English and Japanese documentation.