### PR TITLE
refactor(modelDescriptions): Remove Outdated Models

### DIFF
--- a/apps/www/lib/modelDescriptions.ts
+++ b/apps/www/lib/modelDescriptions.ts
@@ -280,31 +280,11 @@ export const modelDescriptions: modelDescriptionType = {
     vision: true,
     type: "Gemini",
   },
-  "google/gemini-2.5-pro-preview-03-25": {
-    displayName: "Gemini 2.5 Pro (Old)",
-    knowledgeCutoff: "2025/01",
-    vision: true,
-    type: "Gemini",
-  },
   "google/gemini-2.0-flash-001": {
     displayName: "Gemini 2.0 Flash",
     knowledgeCutoff: "2024/06",
     fast: true,
     vision: true,
-    type: "Gemini",
-  },
-  "google/gemini-2.0-flash-lite-001": {
-    displayName: "Gemini 2.0 Flash Lite",
-    knowledgeCutoff: "2024/06",
-    fast: true,
-    vision: true,
-    type: "Gemini",
-  },
-  "google/gemini-1.5-pro": {
-    displayName: "Gemini 1.5 Pro",
-    knowledgeCutoff: "2023/11",
-    vision: true,
-    fast: true,
     type: "Gemini",
   },
   "anthropic/claude-3-7-sonnet-20250219": {
@@ -335,21 +315,6 @@ export const modelDescriptions: modelDescriptionType = {
     fast: true,
     toolDisabled: true,
     type: "DeepSeek",
-  },
-  "openrouter/x-ai/grok-3-beta": {
-    displayName: "Grok 3 Beta (OpenRouter)",
-    vision: true,
-    reasoning: true,
-    knowledgeCutoff: "-",
-    type: "Grok",
-  },
-  "openrouter/x-ai/grok-3-mini-beta": {
-    displayName: "Grok 3 Mini Beta (OpenRouter)",
-    vision: true,
-    reasoning: true,
-    toolDisabled: true,
-    knowledgeCutoff: "-",
-    type: "Grok",
   },
   "xai/grok-3-beta": {
     displayName: "Grok 3 Beta",


### PR DESCRIPTION
This pull request updates the `modelDescriptions` object in `apps/www/lib/modelDescriptions.ts` by removing outdated or redundant model entries. These changes streamline the list of available models and ensure it reflects only the most relevant and up-to-date options.

### Removal of outdated model entries:

* Removed the `google/gemini-2.5-pro-preview-03-25` entry, which represented an older version of the Gemini model.
* Removed the `google/gemini-2.0-flash-lite-001` and `google/gemini-1.5-pro` entries, both of which were legacy Gemini models.

### Streamlining of Grok models:

* Removed the `openrouter/x-ai/grok-3-beta` and `openrouter/x-ai/grok-3-mini-beta` entries in favor of the `xai/grok-3-beta` entry, simplifying the representation of Grok models.