### PR TITLE
Promote canary: voids env gate and session prerender fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,16 @@ STRIPE_WEBHOOK_SECRET=whsec_your-webhook-secret
 
 # AI Providers
 GOOGLE_GENERATIVE_AI_API_KEY=your-google-ai-key
+ANTHROPIC_API_KEY=your-anthropic-key
 GROQ_API_KEY=gsk_your-groq-key
 OPENROUTER_API_KEY=sk-or-your-openrouter-key
+
+# voids.top (optional OpenAI-compatible gateway for platform OpenAI + Anthropic)
+# Set VOIDS_MODE=true (or 1) to enable. Leave unset/false for OpenRouter + Anthropic direct.
+# When VOIDS_MODE is on, VOIDS_API_KEY is required (voids returns 401 without a valid key).
+VOIDS_MODE=
+VOIDS_BASE_URL=https://capi.voids.top/v2
+VOIDS_API_KEY=
 
 # Search
 BRAVE_SEARCH_API_KEY=your-brave-search-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ This file applies to the entire repository tree rooted here. Follow these rules,
 - `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
   Note: These are validated strictly via Zod. Missing/invalid values will cause runtime or startup failures.
 - For Stripe billing/custom checkout, also set `STRIPE_SECRET_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (`STRIPE_WEBHOOK_SECRET` is optional for local development).
+- Optional voids.top gateway: `VOIDS_MODE=true|1` routes platform OpenAI + Anthropic via voids; when enabled `VOIDS_API_KEY` is required; optional `VOIDS_BASE_URL`.
 
 ■ Common Scripts (Bun preferred)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -51,6 +51,12 @@ ANTHROPIC_API_KEY=your-anthropic-key
 GROQ_API_KEY=gsk_your-groq-key
 OPENROUTER_API_KEY=your-openrouter-key
 
+# voids.top gateway (optional)
+# VOIDS_MODE=true routes platform OpenAI + Anthropic through voids.top
+VOIDS_MODE=
+VOIDS_BASE_URL=https://capi.voids.top/v2
+VOIDS_API_KEY=
+
 # Search
 BRAVE_SEARCH_API_KEY=your-brave-search-key
 
@@ -73,6 +79,8 @@ NEXT_PUBLIC_BILLING_DISABLED=1
 When adding or updating supported AI providers/models, also update `src/lib/constants.ts`.
 
 Set `ANTHROPIC_API_KEY` to your Anthropic API key for Claude models. Set `OPENROUTER_API_KEY` to your OpenRouter API key for other routed models.
+
+Optional voids.top mode: set `VOIDS_MODE=true` (or `1`) to send **platform** (non-BYOK) OpenAI and Anthropic traffic through the OpenAI-compatible voids.top gateway. When enabled, **`VOIDS_API_KEY` is required** (voids returns `401 invalid apikey` without it). Optional `VOIDS_BASE_URL` (default `https://capi.voids.top/v2`). When `VOIDS_MODE` is off, OpenAI uses OpenRouter and Anthropic uses `ANTHROPIC_API_KEY`.
 
 #### Generate `BETTER_AUTH_SECRET`
 

--- a/src/app/(auth)/account/[path]/page.tsx
+++ b/src/app/(auth)/account/[path]/page.tsx
@@ -1,17 +1,31 @@
 import { ensureSession } from "@better-auth-ui/react/server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { connection } from "next/server";
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
+import { Suspense } from "react";
 import { Settings } from "@/components/auth/settings/settings";
 import Footer from "@/components/footer";
 import Header from "@/components/header";
+import { Spinner } from "@/components/ui/spinner";
 import { auth } from "@/lib/auth";
 import { getQueryClient } from "@/lib/query-client";
 
 /** Matches AuthProvider viewPaths.settings override (account → "settings"). */
 const ACCOUNT_SETTINGS_PATHS = ["settings", "security"] as const;
 
-export default async function AccountPage({ params }: { params: Promise<{ path: string }> }) {
+function AccountPageFallback() {
+  return (
+    <main className="flex min-h-[50vh] items-center justify-center pt-24" id="main-content">
+      <Spinner className="size-5" />
+    </main>
+  );
+}
+
+async function AccountPageContent({ params }: { params: Promise<{ path: string }> }) {
+  // Defer session/DB work past Cache Components prerender (request-time only).
+  await connection();
+
   const { path } = await params;
 
   if (!(ACCOUNT_SETTINGS_PATHS as readonly string[]).includes(path)) {
@@ -39,5 +53,13 @@ export default async function AccountPage({ params }: { params: Promise<{ path: 
         <Footer />
       </main>
     </HydrationBoundary>
+  );
+}
+
+export default function AccountPage({ params }: { params: Promise<{ path: string }> }) {
+  return (
+    <Suspense fallback={<AccountPageFallback />}>
+      <AccountPageContent params={params} />
+    </Suspense>
   );
 }

--- a/src/app/api/chat/_lib/model.ts
+++ b/src/app/api/chat/_lib/model.ts
@@ -15,8 +15,7 @@ import { assertSafePublicHttpUrl } from "@/lib/network-security";
 import { createDeniOpenRouter } from "@/lib/openrouter-provider";
 import { getUsageSummary, type UsageCategory, UsageLimitError } from "@/lib/usage";
 
-/** OpenAI-compatible free gateway used for platform OpenAI + Anthropic traffic. */
-const VOIDS_BASE_URL = "https://capi.voids.top/v2";
+const DEFAULT_VOIDS_BASE_URL = "https://capi.voids.top/v2";
 
 const openaiEffortOptions = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const anthropicEffortOptions = ["low", "medium", "high", "max"] as const;
@@ -163,13 +162,24 @@ export async function resolveChatModelContext({
     }
   }
 
-  // Platform OpenAI/Anthropic traffic goes through voids.top (OpenAI-compatible).
-  // BYOK keeps native provider SDKs. Google/xAI platform traffic stays on OpenRouter.
-  // Pro mode requires BYOK OpenAI (voids.top has no `*-pro` slugs / reasoning.mode).
-  const usesVoids = !useByok && (providerId === "openai" || providerId === "anthropic");
-  const usesOpenRouter = !useByok && (providerId === "google" || providerId === "xai");
+  // voids.top is opt-in via VOIDS_MODE. When enabled, platform (non-BYOK)
+  // OpenAI + Anthropic traffic uses the OpenAI-compatible voids gateway.
+  // Otherwise OpenAI/Google/xAI use OpenRouter and Anthropic uses ANTHROPIC_API_KEY.
+  // BYOK always keeps native provider SDKs.
+  const voidsModeEnabled = Boolean(env.VOIDS_MODE);
+  const usesVoids =
+    voidsModeEnabled && !useByok && (providerId === "openai" || providerId === "anthropic");
+  const usesOpenRouter =
+    !useByok &&
+    !usesVoids &&
+    (providerId === "openai" || providerId === "google" || providerId === "xai");
+  // Pro: BYOK OpenAI uses reasoning.mode; OpenRouter uses `*-pro` slug.
+  // voids.top has neither, so Pro is disabled on the voids path.
   const useProMode = Boolean(
-    proMode && selectedModel.supportsProMode && useByok && providerId === "openai",
+    proMode &&
+    selectedModel.supportsProMode &&
+    providerId === "openai" &&
+    (useByok || usesOpenRouter),
   );
   const isPremiumModel = Boolean(selectedModel.premium);
   // Pro mode always bills against premium quota (even when the base model is basic).
@@ -212,8 +222,9 @@ export async function resolveChatModelContext({
     }
   }
 
-  // voids.top model ids match constants values (gpt-5.6-sol, claude-fable-5, …).
-  const resolvedModelId = selectedModel.value;
+  // OpenRouter exposes GPT-5.6 Pro as `*-pro`. voids.top does not — keep base id there.
+  const resolvedModelId =
+    useProMode && usesOpenRouter ? `${selectedModel.value}-pro` : selectedModel.value;
 
   const resolvedReasoningEffort = resolveReasoningEffort(
     selectedModel?.efforts ?? false,
@@ -265,8 +276,7 @@ export async function resolveChatModelContext({
       : undefined;
 
   // OpenRouter uses `x-ai/...` for xAI models (not `xai/...`).
-  const openRouterAuthor =
-    selectedModel.author === "xai" ? "x-ai" : selectedModel.author;
+  const openRouterAuthor = selectedModel.author === "xai" ? "x-ai" : selectedModel.author;
   const selectedOpenRouterModelId = selectedModel
     ? resolvedModelId.includes("/")
       ? resolvedModelId
@@ -298,9 +308,17 @@ export async function resolveChatModelContext({
   };
 
   const getVoidsModel = () => {
+    const apiKey = env.VOIDS_API_KEY?.trim();
+    if (!apiKey) {
+      throw new ChatRouteError(500, {
+        error:
+          "VOIDS_API_KEY is required when VOIDS_MODE is enabled. Set a valid voids.top API key in the environment.",
+      });
+    }
+
     const provider = createOpenAI({
-      apiKey: "voids",
-      baseURL: VOIDS_BASE_URL,
+      apiKey,
+      baseURL: env.VOIDS_BASE_URL || DEFAULT_VOIDS_BASE_URL,
       name: "voids",
     });
     // voids.top speaks the Chat Completions API with OpenAI-style model ids
@@ -328,16 +346,20 @@ export async function resolveChatModelContext({
           baseURL: byokBaseUrl,
         });
         model = provider.responses(resolvedModelId);
-      } else {
+      } else if (usesVoids) {
         model = getVoidsModel();
+      } else {
+        model = getOpenRouterModel();
       }
       break;
     }
     case "anthropic": {
       if (useByok) {
         model = getAnthropicModel(byokApiKey, byokBaseUrl);
-      } else {
+      } else if (usesVoids) {
         model = getVoidsModel();
+      } else {
+        model = getAnthropicModel(env.ANTHROPIC_API_KEY);
       }
       break;
     }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -243,10 +243,13 @@ export async function POST(req: Request) {
   const { model, providerOptions, usageCategory, usageUnit, useByok, usesOpenRouter } =
     modelContext;
 
-  // Pro mode only applies on BYOK OpenAI (voids.top platform path has no pro slug).
+  // Pro mode: BYOK OpenAI or OpenRouter platform OpenAI (not voids.top).
   const modelDef = getModelDefinition(baseModel);
   const proMode = Boolean(
-    requestedProMode && modelDef?.supportsProMode && useByok && modelDef.author === "openai",
+    requestedProMode &&
+    modelDef?.supportsProMode &&
+    modelDef.author === "openai" &&
+    (useByok || usesOpenRouter),
   );
 
   const webSearchEnabled = webSearch || forceWebSearch || deepResearch;

--- a/src/app/getting-started/page.tsx
+++ b/src/app/getting-started/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import GettingStartedPage from "@/components/getting-started-page";
+import { Spinner } from "@/components/ui/spinner";
 import { auth } from "@/lib/auth";
 
 export const metadata: Metadata = {
@@ -9,11 +12,28 @@ export const metadata: Metadata = {
   description: "Set up your Deni AI workspace.",
 };
 
-export default async function GettingStarted() {
+function GettingStartedFallback() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <Spinner className="size-5" />
+    </div>
+  );
+}
+
+async function GettingStartedContent() {
+  await connection();
   const hdrs = await headers();
   const session = await auth.api.getSession({ headers: hdrs });
   if (!session) {
     redirect("/");
   }
   return <GettingStartedPage />;
+}
+
+export default function GettingStarted() {
+  return (
+    <Suspense fallback={<GettingStartedFallback />}>
+      <GettingStartedContent />
+    </Suspense>
+  );
 }

--- a/src/app/shared/[shareId]/page.tsx
+++ b/src/app/shared/[shareId]/page.tsx
@@ -2,9 +2,12 @@ import type { UIMessage } from "ai";
 import { safeValidateUIMessages } from "ai";
 import { and, eq } from "drizzle-orm";
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 import dynamic from "next/dynamic";
+import { Suspense } from "react";
+import { Spinner } from "@/components/ui/spinner";
 
 const SharedChatInterface = dynamic(
   () => import("@/components/chat/shared-chat-interface").then((mod) => mod.SharedChatInterface),
@@ -25,7 +28,16 @@ export const metadata: Metadata = {
   description: "View a shared Deni AI conversation.",
 };
 
-export default async function SharedChatPage({ params }: { params: Promise<{ shareId: string }> }) {
+function SharedChatFallback() {
+  return (
+    <div className="flex min-h-[60vh] w-full items-center justify-center">
+      <Spinner className="size-5" />
+    </div>
+  );
+}
+
+async function SharedChatContent({ params }: { params: Promise<{ shareId: string }> }) {
+  await connection();
   const { shareId } = await params;
   const headersPromise = headers();
   const sharePromise = db.select().from(chatShares).where(eq(chatShares.id, shareId));
@@ -95,5 +107,13 @@ export default async function SharedChatPage({ params }: { params: Promise<{ sha
       isOwner={userId === share.ownerId}
       isLoggedIn={!!userId}
     />
+  );
+}
+
+export default function SharedChatPage({ params }: { params: Promise<{ shareId: string }> }) {
+  return (
+    <Suspense fallback={<SharedChatFallback />}>
+      <SharedChatContent params={params} />
+    </Suspense>
   );
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -16,6 +16,18 @@ export const env = createEnv({
     ANTHROPIC_API_KEY: z.string(),
     GROQ_API_KEY: z.string(),
     OPENROUTER_API_KEY: z.string(),
+    /**
+     * When "true" or "1", platform (non-BYOK) OpenAI + Anthropic traffic is
+     * routed through the voids.top OpenAI-compatible gateway.
+     */
+    VOIDS_MODE: z
+      .string()
+      .optional()
+      .transform((value) => value === "true" || value === "1"),
+    /** voids.top Chat Completions base URL (default: https://capi.voids.top/v2). */
+    VOIDS_BASE_URL: z.url().optional(),
+    /** Optional API key for voids.top (default placeholder when omitted). */
+    VOIDS_API_KEY: z.string().optional(),
     BRAVE_SEARCH_API_KEY: z.string(),
     TURNSTILE_SECRET_KEY: z.string(),
     RESEND_API_KEY: z.string().optional(),
@@ -51,6 +63,9 @@ export const env = createEnv({
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     GROQ_API_KEY: process.env.GROQ_API_KEY,
     OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    VOIDS_MODE: process.env.VOIDS_MODE,
+    VOIDS_BASE_URL: process.env.VOIDS_BASE_URL,
+    VOIDS_API_KEY: process.env.VOIDS_API_KEY,
     BRAVE_SEARCH_API_KEY: process.env.BRAVE_SEARCH_API_KEY,
     TURNSTILE_SECRET_KEY: process.env.TURNSTILE_SECRET_KEY,
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,

--- a/src/lib/get-session.ts
+++ b/src/lib/get-session.ts
@@ -1,11 +1,17 @@
 import { cache } from "react";
+import { connection } from "next/server";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 
 /**
  * Request-scoped session lookup. Shared across layout + page so auth is only
  * resolved once per RSC request (React.cache).
+ *
+ * `connection()` defers this past Cache Components prerender so Neon/auth
+ * fetch() is not started (and then aborted) while building the static shell.
+ * Call sites must sit under a <Suspense> boundary.
  */
 export const getSession = cache(async () => {
+  await connection();
   return auth.api.getSession({ headers: await headers() });
 });


### PR DESCRIPTION
## Summary
Promote `canary` to `master` with voids.top env gating and Cache Components session prerender hang fixes.

### Included
- `VOIDS_MODE` / `VOIDS_BASE_URL` / `VOIDS_API_KEY` (API key required when mode is on)
- `connection()` before session/auth DB access under Suspense
- Account, getting-started, and shared chat page prerender safety

## Test plan
- [ ] Deploy with `VOIDS_MODE` + valid `VOIDS_API_KEY`
- [ ] Confirm chat works and session errors no longer spam logs on `/chat` and settings