### PR TITLE
promote: canary → master (memory save + instant nav)

### DIFF
--- a/src/app/(auth)/auth/[path]/page.tsx
+++ b/src/app/(auth)/auth/[path]/page.tsx
@@ -1,14 +1,27 @@
 import { viewPaths } from "@better-auth-ui/core";
 import { magicLinkPlugin } from "@better-auth-ui/core/plugins";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { Auth } from "@/components/auth/auth";
 import { GuestSignInButton } from "@/components/guest-sign-in-button";
+import { Spinner } from "@/components/ui/spinner";
 
 const magicLinkPaths = Object.values(magicLinkPlugin().viewPaths?.auth ?? {});
 
 const validAuthPaths = new Set([...Object.values(viewPaths.auth), ...magicLinkPaths]);
 
-export default async function AuthPage({ params }: { params: Promise<{ path: string }> }) {
+function AuthPageFallback() {
+  return (
+    <main
+      className="flex min-h-screen w-full grow flex-col items-center justify-center gap-4 p-4 md:p-6"
+      id="main-content"
+    >
+      <Spinner className="size-5" />
+    </main>
+  );
+}
+
+async function AuthPageContent({ params }: { params: Promise<{ path: string }> }) {
   const { path } = await params;
 
   if (!validAuthPaths.has(path)) {
@@ -25,5 +38,13 @@ export default async function AuthPage({ params }: { params: Promise<{ path: str
       <Auth path={path} />
       {showGuest ? <GuestSignInButton className="w-full max-w-sm" size="sm" /> : null}
     </main>
+  );
+}
+
+export default function AuthPage({ params }: { params: Promise<{ path: string }> }) {
+  return (
+    <Suspense fallback={<AuthPageFallback />}>
+      <AuthPageContent params={params} />
+    </Suspense>
   );
 }

--- a/src/app/(home)/home/page.tsx
+++ b/src/app/(home)/home/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getExtracted } from "next-intl/server";
+import { Suspense } from "react";
 import { ClientHome } from "./home-client";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -27,7 +28,11 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Home() {
+/**
+ * JSON-LD needs next-intl (cookies/headers for locale). Keep it behind Suspense
+ * so the page shell stays instant under cacheComponents.
+ */
+async function HomeJsonLd() {
   const t = await getExtracted();
   const webApplicationDescription = t(
     "Access the latest AI models without breaking the bank. Deni AI brings premium intelligence to everyone, completely free.",
@@ -96,11 +101,19 @@ export default async function Home() {
   ];
 
   return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+    />
+  );
+}
+
+export default function Home() {
+  return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
-      />
+      <Suspense fallback={null}>
+        <HomeJsonLd />
+      </Suspense>
       <ClientHome />
     </>
   );

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -13,7 +13,7 @@ import {
   type UIMessage,
 } from "ai";
 import { headers } from "next/headers";
-import { NextResponse } from "next/server";
+import { after, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import {
   clearChatGenerationState,
@@ -660,14 +660,19 @@ export async function POST(req: Request) {
           await reconcileConsumedUsage(finalUsageAmount);
         }
 
-        try {
-          await maybeAutoSaveMemories({
-            userId,
-            messages: updatedMessages,
-            enabled: memoryState.profile.autoMemory,
-          });
-        } catch (error) {
-          console.error("Failed to auto-save memories", error);
+        // Memory extraction can take seconds and must not keep the chat SSE
+        // open. Schedule it after the response finishes so the client can end
+        // the request immediately while work continues on the backend.
+        if (memoryState.profile.autoMemory) {
+          after(() =>
+            maybeAutoSaveMemories({
+              userId,
+              messages: updatedMessages,
+              enabled: true,
+            }).catch((error) => {
+              console.error("Failed to auto-save memories", error);
+            }),
+          );
         }
       } catch (error) {
         await rollbackPendingAssistantState();

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,17 +1,12 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { AppSidebar } from "@/components/app-sidebar";
+import { ChatSearch } from "@/components/chat/chat-search";
 import { TwoFactorBanner } from "@/components/two-factor-banner";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { useNewChat } from "@/hooks/use-new-chat";
-
-const AppSidebar = dynamic(() => import("@/components/app-sidebar").then((mod) => mod.AppSidebar));
-const ChatSearch = dynamic(
-  () => import("@/components/chat/chat-search").then((mod) => mod.ChatSearch),
-  { ssr: false },
-);
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   // Track which pathname the dialog was opened for so navigation closes it

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { useExtracted } from "next-intl";
 import DeniAIIcon from "./deni-ai-icon";

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Bot,
   BookOpen,
@@ -11,11 +13,10 @@ import {
   Shield,
   Sparkles,
 } from "lucide-react";
-import { cookies } from "next/headers";
 import Link from "next/link";
 import { useExtracted } from "next-intl";
 import { UserButton } from "@/components/auth/user/user-button";
-import type { AppLocale } from "@/i18n/locales";
+import { changeLocaleAction } from "@/lib/locale-actions";
 import DeniAIIcon from "./deni-ai-icon";
 import { HeaderMegaMenu } from "./header-mega-menu";
 import { LocaleSwitcher } from "./locale-switcher";
@@ -30,6 +31,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "./ui/sheet";
+
 type MegaMenuLink = {
   href: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -41,12 +43,6 @@ type MegaMenuSection = {
   title: string;
   links: MegaMenuLink[];
 };
-
-async function changeLocaleAction(nextLocale: AppLocale) {
-  "use server";
-  const store = await cookies();
-  store.set("locale", nextLocale);
-}
 
 function MobileNavLink({ link }: { link: MegaMenuLink }) {
   const Icon = link.icon;

--- a/src/components/memory/memory-saved-list-card.tsx
+++ b/src/components/memory/memory-saved-list-card.tsx
@@ -6,7 +6,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 
 type MemoryItem = {
@@ -92,31 +91,29 @@ export function MemorySavedListCard({
             {t("Unable to load saved memories right now.")}
           </div>
         ) : items.length ? (
-          <ScrollArea className="max-h-[22rem]">
-            <div className="space-y-2 pr-4">
-              {items.map((item) => (
-                <div
-                  key={item.id}
-                  className="flex items-center justify-between gap-3 rounded-lg border p-3"
-                >
-                  <div className="min-w-0 space-y-1">
-                    <div className="break-words text-sm">{item.content}</div>
-                    <Badge variant="outline">
-                      {item.source === "auto" ? t("AI added") : t("You added")}
-                    </Badge>
-                  </div>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    onClick={() => onDeleteItem(item.id)}
-                    disabled={isDeleting || isClearing}
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
+          <div className="max-h-[22rem] space-y-2 overflow-y-auto overscroll-y-contain pr-1">
+            {items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between gap-3 rounded-lg border p-3"
+              >
+                <div className="min-w-0 space-y-1">
+                  <div className="break-words text-sm">{item.content}</div>
+                  <Badge variant="outline">
+                    {item.source === "auto" ? t("AI added") : t("You added")}
+                  </Badge>
                 </div>
-              ))}
-            </div>
-          </ScrollArea>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => onDeleteItem(item.id)}
+                  disabled={isDeleting || isClearing}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
         ) : (
           <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
             {t("No saved memories yet. Add one manually or let AI learn from your chats.")}


### PR DESCRIPTION
## Summary
Promote `canary` to `master`.

Includes:
- Chat auto-memory save after SSE via `after()` (client no longer waits)
- Memory settings list scroll/overflow fix
- Instant navigation fixes for home/auth shells, Header/Footer client i18n, AppShell static imports

## Test plan
- [ ] Smoke chat stream end + memory persistence
- [ ] Memory settings list scrolls
- [ ] `/home` and `/auth/*` load without Instant blockers for the fixed cases