### PR TITLE
Promote canary: 2FA login flow and memory dedupe

### DIFF
--- a/migrations/0036_curious_silvermane.sql
+++ b/migrations/0036_curious_silvermane.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "two_factor" ADD COLUMN "failed_verification_count" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "two_factor" ADD COLUMN "locked_until" timestamp;

--- a/migrations/meta/0036_snapshot.json
+++ b/migrations/meta/0036_snapshot.json
@@ -1,0 +1,2751 @@
+{
+  "id": "dbfb7352-c8b1-41fe-8e89-ea6dff1f6815",
+  "prevId": "a95e6d00-ce64-4cd8-be09-036bf32fe738",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_user_id_idx": {
+          "name": "api_key_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_key_hash_idx": {
+          "name": "api_key_key_hash_idx",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_user_id_user_id_fk": {
+          "name": "api_key_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_key_hash_unique": {
+          "name": "api_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "twoFactor_secret_idx": {
+          "name": "twoFactor_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "twoFactor_userId_idx": {
+          "name": "twoFactor_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing": {
+      "name": "billing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'inactive'"
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'subscription'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkout_session_id": {
+          "name": "checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flash_offer_ends_at": {
+          "name": "flash_offer_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_paid_at": {
+          "name": "first_paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_fingerprint": {
+          "name": "payment_method_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_funding": {
+          "name": "card_funding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_verified_at": {
+          "name": "card_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_payment_method_fingerprint": {
+          "name": "trial_payment_method_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_used_at": {
+          "name": "trial_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_mode_enabled": {
+          "name": "max_mode_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_mode_usage_basic": {
+          "name": "max_mode_usage_basic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_mode_usage_premium": {
+          "name": "max_mode_usage_premium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_mode_period_start": {
+          "name": "max_mode_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_subscription_item_id": {
+          "name": "stripe_metered_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_user_personal_idx": {
+          "name": "billing_user_personal_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "organization_id IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_user_org_idx": {
+          "name": "billing_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "organization_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_customer_idx": {
+          "name": "billing_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_subscription_idx": {
+          "name": "billing_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_payment_method_fingerprint_idx": {
+          "name": "billing_payment_method_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "payment_method_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_trial_payment_method_fingerprint_idx": {
+          "name": "billing_trial_payment_method_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "trial_payment_method_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_user_id_user_id_fk": {
+          "name": "billing_user_id_user_id_fk",
+          "tableFrom": "billing",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_generation_id": {
+          "name": "active_generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_user_id_idx": {
+          "name": "chats_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_project_id_idx": {
+          "name": "chats_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chats_user_updated_idx": {
+          "name": "chats_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_user_id_user_id_fk": {
+          "name": "chats_user_id_user_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chats_project_id_projects_id_fk": {
+          "name": "chats_project_id_projects_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_auth_code": {
+      "name": "device_auth_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issued_api_key_enc": {
+          "name": "issued_api_key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_api_key_id": {
+          "name": "issued_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_auth_code_user_code_idx": {
+          "name": "device_auth_code_user_code_idx",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_auth_code_device_code_idx": {
+          "name": "device_auth_code_device_code_idx",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_auth_code_user_id_user_id_fk": {
+          "name": "device_auth_code_user_id_user_id_fk",
+          "tableFrom": "device_auth_code",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_auth_code_user_code_unique": {
+          "name": "device_auth_code_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code"]
+        },
+        "device_auth_code_device_code_unique": {
+          "name": "device_auth_code_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_item": {
+      "name": "memory_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_item_user_id_idx": {
+          "name": "memory_item_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_item_user_id_user_id_fk": {
+          "name": "memory_item_user_id_user_id_fk",
+          "tableFrom": "memory_item",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_memory": {
+      "name": "user_memory",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "friendliness": {
+          "name": "friendliness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'friendly'"
+        },
+        "warmth": {
+          "name": "warmth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'warm'"
+        },
+        "emoji_style": {
+          "name": "emoji_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'light'"
+        },
+        "auto_memory": {
+          "name": "auto_memory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_memory_user_id_user_id_fk": {
+          "name": "user_memory_user_id_user_id_fk",
+          "tableFrom": "user_memory",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_files": {
+      "name": "project_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'application/octet-stream'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_files_project_id_idx": {
+          "name": "project_files_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_files_user_id_idx": {
+          "name": "project_files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_files_project_id_projects_id_fk": {
+          "name": "project_files_project_id_projects_id_fk",
+          "tableFrom": "project_files",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_files_user_id_user_id_fk": {
+          "name": "project_files_user_id_user_id_fk",
+          "tableFrom": "project_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'amber'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_user_id_idx": {
+          "name": "projects_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_user_id_user_id_fk": {
+          "name": "projects_user_id_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_enc": {
+          "name": "key_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_key_user_provider_idx": {
+          "name": "provider_key_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_setting": {
+      "name": "provider_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefer_byok": {
+          "name": "prefer_byok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_style": {
+          "name": "api_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_setting_user_provider_idx": {
+          "name": "provider_setting_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_setting_user_id_user_id_fk": {
+          "name": "provider_setting_user_id_user_id_fk",
+          "tableFrom": "provider_setting",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_share_recipients": {
+      "name": "chat_share_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_share_recipients_share_id_idx": {
+          "name": "chat_share_recipients_share_id_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_share_recipients_recipient_id_idx": {
+          "name": "chat_share_recipients_recipient_id_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_share_recipients_share_recipient_idx": {
+          "name": "chat_share_recipients_share_recipient_idx",
+          "columns": [
+            {
+              "expression": "share_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_share_recipients_share_id_chat_shares_id_fk": {
+          "name": "chat_share_recipients_share_id_chat_shares_id_fk",
+          "tableFrom": "chat_share_recipients",
+          "tableTo": "chat_shares",
+          "columnsFrom": ["share_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_share_recipients_recipient_id_user_id_fk": {
+          "name": "chat_share_recipients_recipient_id_user_id_fk",
+          "tableFrom": "chat_share_recipients",
+          "tableTo": "user",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_shares": {
+      "name": "chat_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "share_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "allow_fork": {
+          "name": "allow_fork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_shares_chat_id_idx": {
+          "name": "chat_shares_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_shares_owner_id_idx": {
+          "name": "chat_shares_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_shares_chat_id_chats_id_fk": {
+          "name": "chat_shares_chat_id_chats_id_fk",
+          "tableFrom": "chat_shares",
+          "tableTo": "chats",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_shares_owner_id_user_id_fk": {
+          "name": "chat_shares_owner_id_user_id_fk",
+          "tableFrom": "chat_shares",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_member_usage_policy": {
+      "name": "team_member_usage_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_mode_enabled": {
+          "name": "max_mode_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_mode_limit_basic": {
+          "name": "max_mode_limit_basic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_mode_limit_premium": {
+          "name": "max_mode_limit_premium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_member_usage_policy_org_user_idx": {
+          "name": "team_member_usage_policy_org_user_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_member_usage_policy_organization_id_organization_id_fk": {
+          "name": "team_member_usage_policy_organization_id_organization_id_fk",
+          "tableFrom": "team_member_usage_policy",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_usage_policy_user_id_user_id_fk": {
+          "name": "team_member_usage_policy_user_id_user_id_fk",
+          "tableFrom": "team_member_usage_policy",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_usage_audit_log": {
+      "name": "team_usage_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_usage_audit_log_org_created_at_idx": {
+          "name": "team_usage_audit_log_org_created_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_usage_audit_log_organization_id_organization_id_fk": {
+          "name": "team_usage_audit_log_organization_id_organization_id_fk",
+          "tableFrom": "team_usage_audit_log",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_usage_audit_log_actor_user_id_user_id_fk": {
+          "name": "team_usage_audit_log_actor_user_id_user_id_fk",
+          "tableFrom": "team_usage_audit_log",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_usage_audit_log_target_user_id_user_id_fk": {
+          "name": "team_usage_audit_log_target_user_id_user_id_fk",
+          "tableFrom": "team_usage_audit_log",
+          "tableTo": "user",
+          "columnsFrom": ["target_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_usage_policy": {
+      "name": "team_usage_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_max_mode_enabled": {
+          "name": "default_max_mode_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_max_mode_limit_basic": {
+          "name": "default_max_mode_limit_basic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_max_mode_limit_premium": {
+          "name": "default_max_mode_limit_premium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_usage_policy_organization_idx": {
+          "name": "team_usage_policy_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_usage_policy_organization_id_organization_id_fk": {
+          "name": "team_usage_policy_organization_id_organization_id_fk",
+          "tableFrom": "team_usage_policy",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_quota": {
+      "name": "usage_quota",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit_amount": {
+          "name": "limit_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usage_quota_user_category_idx": {
+          "name": "usage_quota_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_quota_user_id_user_id_fk": {
+          "name": "usage_quota_user_id_user_id_fk",
+          "tableFrom": "usage_quota",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.share_visibility": {
+      "name": "share_visibility",
+      "schema": "public",
+      "values": ["public", "private"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1782137864943,
       "tag": "0035_fancy_raza",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1784730469778,
+      "tag": "0036_curious_silvermane",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(auth)/auth/[path]/page.tsx
+++ b/src/app/(auth)/auth/[path]/page.tsx
@@ -2,13 +2,17 @@ import { viewPaths } from "@better-auth-ui/core";
 import { magicLinkPlugin } from "@better-auth-ui/core/plugins";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-import { Auth } from "@/components/auth/auth";
+import { Auth, TWO_FACTOR_VIEW_PATH } from "@/components/auth/auth";
 import { GuestSignInButton } from "@/components/guest-sign-in-button";
 import { Spinner } from "@/components/ui/spinner";
 
 const magicLinkPaths = Object.values(magicLinkPlugin().viewPaths?.auth ?? {});
 
-const validAuthPaths = new Set([...Object.values(viewPaths.auth), ...magicLinkPaths]);
+const validAuthPaths = new Set([
+  ...Object.values(viewPaths.auth),
+  ...magicLinkPaths,
+  TWO_FACTOR_VIEW_PATH,
+]);
 
 function AuthPageFallback() {
   return (

--- a/src/components/auth/auth.tsx
+++ b/src/components/auth/auth.tsx
@@ -10,6 +10,7 @@ import { ResetPassword } from "./reset-password";
 import { SignIn } from "./sign-in";
 import { SignOut } from "./sign-out";
 import { SignUp } from "./sign-up";
+import { TwoFactor } from "./two-factor";
 import { VerifyEmail } from "./verify-email";
 
 export type AuthProps = {
@@ -18,7 +19,7 @@ export type AuthProps = {
   socialLayout?: SocialLayout;
   socialPosition?: "top" | "bottom";
   /** @remarks `AuthView` */
-  view?: AuthView;
+  view?: AuthView | "twoFactor";
 };
 
 /**
@@ -28,13 +29,17 @@ export type AuthProps = {
  */
 const PASSWORD_ONLY_VIEWS = ["signUp", "forgotPassword", "resetPassword"];
 
-const AUTH_VIEWS: Partial<Record<AuthView, ComponentType<AuthProps>>> = {
+/** Path segment for the second-factor challenge (not in better-auth-ui viewPaths). */
+export const TWO_FACTOR_VIEW_PATH = "two-factor";
+
+const AUTH_VIEWS: Partial<Record<AuthView | "twoFactor", ComponentType<AuthProps>>> = {
   signIn: SignIn,
   signOut: SignOut,
   signUp: SignUp,
   forgotPassword: ForgotPassword,
   resetPassword: ResetPassword,
   verifyEmail: VerifyEmail,
+  twoFactor: TwoFactor,
 };
 
 /**
@@ -59,14 +64,20 @@ export function Auth({ className, path, socialLayout, socialPosition, view }: Au
   }
 
   const authView =
-    view || (Object.keys(viewPaths.auth) as AuthView[]).find((key) => viewPaths.auth[key] === path);
+    view ||
+    (path === TWO_FACTOR_VIEW_PATH
+      ? "twoFactor"
+      : (Object.keys(viewPaths.auth) as AuthView[]).find((key) => viewPaths.auth[key] === path));
 
   // When email + password auth is disabled, password-only views (signUp,
   // forgotPassword, resetPassword) have no meaning. Redirect them to signIn,
   // where a plugin's `fallbackViews.auth.signIn` (e.g. magic link) takes
   // over as the primary entry point.
   const shouldRedirectToSignIn =
-    !emailAndPassword?.enabled && authView && PASSWORD_ONLY_VIEWS.includes(authView);
+    !emailAndPassword?.enabled &&
+    authView &&
+    authView !== "twoFactor" &&
+    PASSWORD_ONLY_VIEWS.includes(authView);
 
   useEffect(() => {
     if (shouldRedirectToSignIn) {

--- a/src/components/auth/sign-in.tsx
+++ b/src/components/auth/sign-in.tsx
@@ -18,6 +18,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
+import { TWO_FACTOR_PATH } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 import { ProviderButtons, type SocialLayout } from "./provider-buttons";
 
@@ -66,7 +67,20 @@ export function SignIn({ className, socialLayout, socialPosition = "bottom" }: S
 
       resetFetchOptions();
     },
-    onSuccess: () => navigate({ to: redirectTo }),
+    onSuccess: (data) => {
+      // When 2FA is enabled, better-auth returns twoFactorRedirect instead of a
+      // session. Send users to the verify page (twoFactorClient also redirects).
+      if (
+        data &&
+        typeof data === "object" &&
+        "twoFactorRedirect" in data &&
+        (data as { twoFactorRedirect?: boolean }).twoFactorRedirect
+      ) {
+        navigate({ to: TWO_FACTOR_PATH });
+        return;
+      }
+      navigate({ to: redirectTo });
+    },
   });
 
   const signInMutating = useIsMutating({

--- a/src/components/auth/two-factor.tsx
+++ b/src/components/auth/two-factor.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useAuth } from "@better-auth-ui/react";
+import { useExtracted } from "next-intl";
+import { type FormEvent, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldDescription, FieldError, FieldGroup } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+
+export type TwoFactorProps = {
+  className?: string;
+};
+
+type VerifyMode = "totp" | "backup";
+
+/**
+ * Second-factor verification after email/password sign-in when 2FA is enabled.
+ * Accepts a TOTP code from an authenticator app, or a one-time backup code.
+ */
+export function TwoFactor({ className }: TwoFactorProps) {
+  const t = useExtracted();
+  const { basePaths, redirectTo, viewPaths, navigate, Link } = useAuth();
+
+  const [mode, setMode] = useState<VerifyMode>("totp");
+  const [totpCode, setTotpCode] = useState("");
+  const [backupCode, setBackupCode] = useState("");
+  const [trustDevice, setTrustDevice] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+  const [isPending, setIsPending] = useState(false);
+
+  const signInHref = `${basePaths.auth}/${viewPaths.auth.signIn}`;
+
+  const completeSignIn = () => {
+    navigate({ to: redirectTo, replace: true });
+  };
+
+  const handleError = (message?: string) => {
+    setError(message || t("Invalid verification code"));
+    setTotpCode("");
+    setBackupCode("");
+  };
+
+  const verifyTotp = async (code: string) => {
+    if (code.length !== 6 || isPending) return;
+
+    setIsPending(true);
+    setError(undefined);
+
+    const { error: verifyError } = await authClient.twoFactor.verifyTotp({
+      code,
+      trustDevice,
+    });
+
+    setIsPending(false);
+
+    if (verifyError) {
+      handleError(verifyError.message);
+      return;
+    }
+
+    toast.success(t("Signed in successfully"));
+    completeSignIn();
+  };
+
+  const verifyBackup = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const code = backupCode.trim();
+    if (!code || isPending) return;
+
+    setIsPending(true);
+    setError(undefined);
+
+    const { error: verifyError } = await authClient.twoFactor.verifyBackupCode({
+      code,
+      trustDevice,
+    });
+
+    setIsPending(false);
+
+    if (verifyError) {
+      handleError(verifyError.message);
+      return;
+    }
+
+    toast.success(t("Signed in successfully"));
+    completeSignIn();
+  };
+
+  return (
+    <Card className={cn("w-full max-w-sm", className)}>
+      <CardHeader>
+        <CardTitle className="text-xl font-semibold">{t("Two-factor authentication")}</CardTitle>
+        <CardDescription>
+          {mode === "totp"
+            ? t("Enter the 6-digit code from your authenticator app")
+            : t("Enter one of your backup recovery codes")}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        <div className="flex flex-col gap-6">
+          {mode === "totp" ? (
+            <FieldGroup>
+              <Field data-invalid={!!error}>
+                <Label htmlFor="totp-code">{t("Authentication code")}</Label>
+                <div className="flex justify-center">
+                  <InputOTP
+                    id="totp-code"
+                    maxLength={6}
+                    value={totpCode}
+                    onChange={(value) => {
+                      setTotpCode(value);
+                      setError(undefined);
+                      if (value.length === 6) {
+                        void verifyTotp(value);
+                      }
+                    }}
+                    disabled={isPending}
+                    autoFocus
+                    containerClassName="gap-2"
+                    aria-invalid={!!error}
+                  >
+                    <InputOTPGroup>
+                      <InputOTPSlot index={0} />
+                      <InputOTPSlot index={1} />
+                      <InputOTPSlot index={2} />
+                      <InputOTPSlot index={3} />
+                      <InputOTPSlot index={4} />
+                      <InputOTPSlot index={5} />
+                    </InputOTPGroup>
+                  </InputOTP>
+                </div>
+                <FieldError>{error}</FieldError>
+              </Field>
+
+              <Field className="my-1">
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    id="trustDevice-totp"
+                    checked={trustDevice}
+                    onCheckedChange={(checked) => setTrustDevice(checked === true)}
+                    disabled={isPending}
+                  />
+                  <Label htmlFor="trustDevice-totp" className="cursor-pointer text-sm font-normal">
+                    {t("Trust this device for 30 days")}
+                  </Label>
+                </div>
+              </Field>
+
+              <Button
+                type="button"
+                disabled={isPending || totpCode.length !== 6}
+                onClick={() => void verifyTotp(totpCode)}
+              >
+                {isPending && <Spinner />}
+                {t("Verify")}
+              </Button>
+            </FieldGroup>
+          ) : (
+            <form onSubmit={(e) => void verifyBackup(e)}>
+              <FieldGroup>
+                <Field data-invalid={!!error}>
+                  <Label htmlFor="backup-code">{t("Backup code")}</Label>
+                  <Input
+                    id="backup-code"
+                    name="backupCode"
+                    type="text"
+                    autoComplete="one-time-code"
+                    value={backupCode}
+                    onChange={(e) => {
+                      setBackupCode(e.target.value);
+                      setError(undefined);
+                    }}
+                    placeholder={t("Enter backup code")}
+                    required
+                    disabled={isPending}
+                    autoFocus
+                    aria-invalid={!!error}
+                  />
+                  <FieldError>{error}</FieldError>
+                </Field>
+
+                <Field className="my-1">
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="trustDevice-backup"
+                      checked={trustDevice}
+                      onCheckedChange={(checked) => setTrustDevice(checked === true)}
+                      disabled={isPending}
+                    />
+                    <Label
+                      htmlFor="trustDevice-backup"
+                      className="cursor-pointer text-sm font-normal"
+                    >
+                      {t("Trust this device for 30 days")}
+                    </Label>
+                  </div>
+                </Field>
+
+                <Button type="submit" disabled={isPending || !backupCode.trim()}>
+                  {isPending && <Spinner />}
+                  {t("Verify")}
+                </Button>
+              </FieldGroup>
+            </form>
+          )}
+
+          <div className="flex flex-col gap-3 items-center w-full">
+            <button
+              type="button"
+              className="text-sm underline-offset-4 hover:underline text-muted-foreground"
+              disabled={isPending}
+              onClick={() => {
+                setMode(mode === "totp" ? "backup" : "totp");
+                setError(undefined);
+                setTotpCode("");
+                setBackupCode("");
+              }}
+            >
+              {mode === "totp"
+                ? t("Use a backup code instead")
+                : t("Use authenticator app instead")}
+            </button>
+
+            <FieldDescription className="text-center">
+              <Link href={signInHref} className="underline underline-offset-4">
+                {t("Back to sign in")}
+              </Link>
+            </FieldDescription>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -94,6 +94,9 @@ export const twoFactor = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     verified: boolean("verified").default(true),
+    // Account lockout after repeated failed second-factor attempts (better-auth 2FA plugin)
+    failedVerificationCount: integer("failed_verification_count").default(0),
+    lockedUntil: timestamp("locked_until"),
   },
   (table) => [
     index("twoFactor_secret_idx").on(table.secret),

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -12,11 +12,21 @@ if (!baseURL) {
   throw new Error("NEXT_PUBLIC_BETTER_AUTH_URL is required");
 }
 
+/** Path for second-factor verification after credential sign-in. */
+export const TWO_FACTOR_PATH = "/auth/two-factor";
+
 export const authClient = createAuthClient({
   baseURL,
   plugins: [
     anonymousClient(),
-    twoFactorClient(),
+    twoFactorClient({
+      // Prefer SPA navigation when possible; fall back is still a hard assign so
+      // users never land on /chat without a completed second factor.
+      onTwoFactorRedirect() {
+        if (typeof window === "undefined") return;
+        window.location.assign(TWO_FACTOR_PATH);
+      },
+    }),
     lastLoginMethodClient(),
     passkeyClient(),
     organizationClient(),

--- a/src/lib/memory.ts
+++ b/src/lib/memory.ts
@@ -16,7 +16,14 @@ export type PersonalizationProfile = {
 };
 
 const memoryExtractionSchema = z.object({
-  memories: z.array(z.string().trim().min(1).max(240)).max(3),
+  /** False when nothing durable and new is worth saving. */
+  hasNew: z.boolean(),
+  memories: z
+    .array(z.string().trim().min(1).max(240))
+    .max(3)
+    .describe(
+      "Only brand-new durable facts not already covered by existing memories. Empty when hasNew is false.",
+    ),
 });
 
 const defaultProfile: PersonalizationProfile = {
@@ -133,34 +140,69 @@ function getLatestUserText(messages: UIMessage[]) {
 }
 
 function normalizeMemoryText(value: string) {
-  return value
-    .normalize("NFKC")
-    .toLowerCase()
-    .replace(/[`"'.,!?(){}[\]:;]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return (
+    value
+      .normalize("NFKC")
+      .toLowerCase()
+      // Strip common list/label prefixes so "Name: rai" ≈ "ユーザーの名前は rai"
+      .replace(
+        /^(?:[-*•]\s*)?(?:name|user(?:'s)? name|preferred language|language|role|職|名前|言語)[:：\s]+/i,
+        "",
+      )
+      .replace(/[`"'「」『』.,!?！？。、()（）{}[\]【】:;：；]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
 }
 
 function tokenizeMemory(value: string) {
-  return normalizeMemoryText(value)
+  const normalized = normalizeMemoryText(value);
+  // Prefer space-split for Latin; fall back to CJK bigrams when unspaced.
+  const spaceTokens = normalized
     .split(" ")
     .map((token) => token.trim())
-    .filter(Boolean);
+    .filter((token) => token.length > 0);
+
+  if (spaceTokens.length >= 2 || !/[\u3040-\u30ff\u3400-\u9fff]/.test(normalized)) {
+    return spaceTokens.filter((token) => token.length > 1 || /^[a-z0-9]+$/i.test(token));
+  }
+
+  const compact = normalized.replace(/\s+/g, "");
+  if (compact.length <= 2) {
+    return compact ? [compact] : [];
+  }
+
+  const bigrams: string[] = [];
+  for (let i = 0; i < compact.length - 1; i += 1) {
+    bigrams.push(compact.slice(i, i + 2));
+  }
+  return bigrams;
 }
 
 function getLabeledMemoryFingerprint(value: string) {
+  const raw = value.normalize("NFKC").trim();
   const normalized = normalizeMemoryText(value);
 
-  const nameMatch = normalized.match(/^(?:user s name is|name)\s+(.+)$/);
+  const nameMatch =
+    raw.match(/^(?:user(?:'s)? name is|name|名前)[:：\s]+(.+)$/i) ??
+    normalized.match(/^(?:name|名前)\s+(.+)$/);
   if (nameMatch) {
-    return `name:${nameMatch[1].trim()}`;
+    return `name:${normalizeMemoryText(nameMatch[1])}`;
   }
 
-  const languageMatch = normalized.match(
-    /^(?:user speaks|preferred language is|preferred language|language|speaks)\s+(.+)$/,
-  );
+  const languageMatch =
+    raw.match(
+      /^(?:user speaks|preferred language is|preferred language|language|speaks|言語|preferred language)[:：\s]+(.+)$/i,
+    ) ?? normalized.match(/^(?:language|言語|speaks)\s+(.+)$/);
   if (languageMatch) {
-    return `language:${languageMatch[1].trim()}`;
+    return `language:${normalizeMemoryText(languageMatch[1])}`;
+  }
+
+  const roleMatch =
+    raw.match(/^(?:role|職|職業|役割)[:：\s]+(.+)$/i) ??
+    normalized.match(/^(?:role|職|職業|役割)\s+(.+)$/);
+  if (roleMatch) {
+    return `role:${normalizeMemoryText(roleMatch[1])}`;
   }
 
   return null;
@@ -168,7 +210,49 @@ function getLabeledMemoryFingerprint(value: string) {
 
 function labeledMemoryFingerprintsMatch(left: string, right: string) {
   // Content equality for dedupe labels — not a security comparison.
-  return left === right;
+  if (left === right) {
+    return true;
+  }
+
+  // Same fact slot (name/language/role) with near-equal values still collides.
+  const [leftKey, ...leftRest] = left.split(":");
+  const [rightKey, ...rightRest] = right.split(":");
+  if (!leftKey || leftKey !== rightKey) {
+    return false;
+  }
+
+  const leftVal = leftRest.join(":");
+  const rightVal = rightRest.join(":");
+  if (!leftVal || !rightVal) {
+    return false;
+  }
+
+  if (leftVal === rightVal || leftVal.includes(rightVal) || rightVal.includes(leftVal)) {
+    return true;
+  }
+
+  return jaccardSimilarity(tokenizeMemory(leftVal), tokenizeMemory(rightVal)) >= 0.5;
+}
+
+function jaccardSimilarity(left: string[], right: string[]) {
+  if (left.length === 0 || right.length === 0) {
+    return 0;
+  }
+  const rightSet = new Set(right);
+  let intersection = 0;
+  const union = new Set(left);
+  for (const token of left) {
+    if (rightSet.has(token)) {
+      intersection += 1;
+    }
+  }
+  for (const token of right) {
+    union.add(token);
+  }
+  if (union.size === 0) {
+    return 0;
+  }
+  return intersection / union.size;
 }
 
 function isNearDuplicateMemory(candidate: string, existing: string) {
@@ -194,12 +278,14 @@ function isNearDuplicateMemory(candidate: string, existing: string) {
     return true;
   }
 
+  // Substring containment (handles rephrases that only add/remove filler).
   if (
     candidateNormalized.includes(existingNormalized) ||
     existingNormalized.includes(candidateNormalized)
   ) {
     const shorterLength = Math.min(candidateNormalized.length, existingNormalized.length);
-    if (shorterLength >= 4) {
+    // CJK can be short but still meaningful (e.g. "日本語").
+    if (shorterLength >= 2) {
       return true;
     }
   }
@@ -215,6 +301,11 @@ function isNearDuplicateMemory(candidate: string, existing: string) {
     return true;
   }
 
+  // Overlapping multi-token facts (e.g. "prefers concise answers" vs "likes short replies").
+  if (jaccardSimilarity(candidateTokens, existingTokens) >= 0.55) {
+    return true;
+  }
+
   return false;
 }
 
@@ -223,6 +314,41 @@ function dedupeMemories(memories: string[]) {
     return !memories.slice(0, index).some((existing) => isNearDuplicateMemory(memory, existing));
   });
 }
+
+function formatExistingMemoriesForAgent(existingMemories: string[]) {
+  if (existingMemories.length === 0) {
+    return "None yet.";
+  }
+
+  // Newest-ish order is not critical for the agent; keep stable list order from DB.
+  // Cap extremely large lists so the extraction prompt stays focused.
+  const MAX_SHOWN = 80;
+  const shown = existingMemories.slice(-MAX_SHOWN);
+  const omitted = existingMemories.length - shown.length;
+  const lines = shown.map((item, index) => `${index + 1}. ${item}`);
+  if (omitted > 0) {
+    lines.unshift(`(${omitted} older memories omitted)`);
+  }
+  return lines.join("\n");
+}
+
+const MEMORY_EXTRACTION_SYSTEM = `You are Deni AI's memory curator.
+
+You will be given:
+1) The user's EXISTING saved memories (already stored — treat them as ground truth).
+2) Recent user messages from the current chat.
+
+Your job is ONLY to decide whether those recent messages add durable facts that are NOT already covered by existing memories.
+
+Rules:
+- Read existing memories FIRST. If a fact is already present (even with different wording, language, or label style), do NOT save it again.
+- Prefer hasNew=false and memories=[] in almost all cases. Silence is correct when nothing is new.
+- Save at most 3 brand-new durable items. Prefer 0–1.
+- Durable = stable preferences, identity, constraints, tools, or long-lived context (name, language, role, coding stack, always-on preferences).
+- NOT durable = one-off tasks, transient questions, secrets/credentials, temporary debugging, greetings, or anything already implied by existing memories.
+- Use short canonical labels so future dedupe is easy, e.g. "Name: rai", "Preferred language: Japanese", "Role: Deni AI owner".
+- Do not restate, rephrase, translate, or "improve" existing memories.
+- Do not invent facts the user did not clearly state.`;
 
 export async function maybeAutoSaveMemories({
   userId,
@@ -242,16 +368,34 @@ export async function maybeAutoSaveMemories({
     return;
   }
 
+  // Skip trivial turns that almost never produce durable memory.
+  if (transcript.replace(/\s+/g, "").length < 8) {
+    return;
+  }
+
   const existingItems = await db.select().from(memoryItem).where(eq(memoryItem.userId, userId));
   const existingMemories = existingItems.map((item) => item.content.trim()).filter(Boolean);
+  const existingBlock = formatExistingMemoriesForAgent(existingMemories);
 
   const { object } = await generateObject({
     model: openrouter.chat("google/gemini-3-flash-preview"),
     schema: memoryExtractionSchema,
-    system:
-      "Extract only durable user preferences or facts worth remembering for future chats. Ignore transient requests, one-off tasks, secrets, and credentials. Return at most 3 concise memory strings. Use canonical wording so duplicates collapse cleanly, for example `Name: rai`, `Preferred language: Japanese`, `Role: Deni AI owner`. Do not restate the same fact in multiple ways.",
-    prompt: `Existing memories:\n${existingMemories.map((item) => `- ${item}`).join("\n") || "None"}\n\nRecent user messages:\n${transcript}`,
+    system: MEMORY_EXTRACTION_SYSTEM,
+    // Existing memories first so the model grounds against them before reading the chat.
+    prompt: [
+      "## Existing memories (already saved — do not duplicate)",
+      existingBlock,
+      "",
+      "## Recent user messages",
+      transcript,
+      "",
+      "Return hasNew=false and memories=[] unless the recent messages clearly introduce durable facts missing above.",
+    ].join("\n"),
   });
+
+  if (!object.hasNew) {
+    return;
+  }
 
   const freshMemories = dedupeMemories(
     object.memories

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,6 +1,6 @@
-export const appVersion = "7.6.0";
-export const appCodename = "Crystal Tiger";
-export const appDate = "2026-07-11";
+export const appVersion = "7.6.1";
+export const appCodename = "Emerald Tiger";
+export const appDate = "2026-07-23";
 
 const appHashPayload = [appVersion, appDate].join(":");
 export const appHash = globalThis.btoa(appHashPayload);

--- a/tools/codenames.json
+++ b/tools/codenames.json
@@ -10,6 +10,7 @@
     "Iron Wolf",
     "Thunder Falcon",
     "Lunar Hawk",
-    "Crystal Tiger"
+    "Crystal Tiger",
+    "Emerald Tiger"
   ]
 }


### PR DESCRIPTION
## Summary

Promote `canary` to `master`.

- **2FA login fix**: After email/password sign-in with two-factor enabled, users are redirected to `/auth/two-factor` to enter a TOTP or backup code (instead of landing on `/chat` with no session).
- **Schema**: Add `failed_verification_count` and `locked_until` on `two_factor` for better-auth account lockout (`migrations/0036_curious_silvermane.sql`).
- **Memory**: Harden memory dedupe logic.

## Deploy notes

Apply migration after deploy:

```bash
bun run db:migrate
```

## Test plan

- [ ] Sign in with a 2FA-enabled account → land on `/auth/two-factor`
- [ ] Submit a valid authenticator code → session created, redirect to app
- [ ] Invalid code shows an error and does not create a session
- [ ] Backup code path works
- [ ] Account without 2FA still signs in to the app as before
- [ ] Confirm migration applied on target DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two-factor authentication verification with authenticator-app codes and backup codes.
  - Added an option to trust a device for 30 days.
  - Added automatic routing to the two-factor verification step after sign-in.

- **Bug Fixes**
  - Improved memory extraction and duplicate detection to reduce repetitive saved memories.
  - Added protection against repeated failed verification attempts.

- **Chores**
  - Updated the application release to version 7.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->