### PR TITLE
fix: restore OpenRouter reasoning options and live Thinking UI

### DIFF
--- a/src/app/api/chat/_lib/model.ts
+++ b/src/app/api/chat/_lib/model.ts
@@ -448,9 +448,32 @@ export async function resolveChatModelContext({
       : {}),
   };
 
-  // When routing through OpenRouter, wrap provider-specific options so they are
-  // forwarded in OpenRouter-compatible format. voids.top only understands OpenAI
-  // chat-style options (and only for OpenAI-authored models).
+  // OpenRouter uses a unified top-level `reasoning` body field
+  // (`providerOptions.openrouter.reasoning`), not nested AI SDK
+  // openai/google/xai option shapes. Nesting those under
+  // `openrouter.providerOptions` was a no-op — the OR provider spreads
+  // `providerOptions.openrouter` into the request body as-is.
+  // https://openrouter.ai/docs/use-cases/reasoning-tokens
+  // https://github.com/OpenRouterTeam/ai-sdk-provider#passing-extra-body-to-openrouter
+  const openRouterReasoningEffort =
+    openaiReasoningEffort ?? googleThinkingLevel ?? xaiReasoningEffort ?? undefined;
+  const openRouterReasoning =
+    openRouterReasoningEffort !== undefined
+      ? {
+          // OpenRouter accepts max/xhigh/high/medium/low/minimal/none.
+          effort: openRouterReasoningEffort as
+            | "max"
+            | "xhigh"
+            | "high"
+            | "medium"
+            | "low"
+            | "minimal"
+            | "none",
+        }
+      : undefined;
+
+  // voids.top only understands OpenAI chat-style options (and only for
+  // OpenAI-authored models). Native BYOK / Anthropic keep provider SDK options.
   const providerOptions: ChatProviderOptions = (
     usesVoids
       ? providerId === "openai" && openaiProviderOptions
@@ -458,8 +481,8 @@ export async function resolveChatModelContext({
         : {}
       : useByok || providerId === "anthropic"
         ? directProviderOptions
-        : usesOpenRouter && Object.keys(directProviderOptions).length > 0
-          ? { openrouter: { providerOptions: directProviderOptions } }
+        : usesOpenRouter && openRouterReasoning
+          ? { openrouter: { reasoning: openRouterReasoning } }
           : {}
   ) as ChatProviderOptions;
 

--- a/src/components/chat/assistant-message-parts.tsx
+++ b/src/components/chat/assistant-message-parts.tsx
@@ -58,23 +58,40 @@ export function AssistantMessageChainOfThought({
 }: AssistantMessageChainOfThoughtProps) {
   const t = useExtracted();
 
-  if (reasoningParts.length === 0) {
+  // OpenAI (via OpenRouter) often streams only encrypted reasoning first and
+  // delivers a visible summary with/just before the final answer. Show a
+  // Thinking placeholder for the whole pre-answer phase so the UI looks like
+  // thought-in-progress, not a blank wait.
+  const isThinking = isStreamingThis && !hasTextParts;
+
+  if (reasoningParts.length === 0 && !isThinking) {
     return null;
   }
 
   return (
-    <ChainOfThought defaultOpen={isStreamingThis}>
+    <ChainOfThought defaultOpen={isThinking || isStreamingThis}>
       <ChainOfThoughtHeader>
-        {isStreamingThis && !hasTextParts ? (
+        {isThinking ? (
           <Shimmer duration={2}>{t("Thinking...")}</Shimmer>
         ) : (
           t("Thought process")
         )}
       </ChainOfThoughtHeader>
       <ChainOfThoughtContent>
+        {reasoningParts.length === 0 && isThinking ? (
+          <ChainOfThoughtStep
+            key={`${messageId}-cot-thinking`}
+            icon={BrainIcon}
+            label={<Shimmer duration={2}>{t("Thinking...")}</Shimmer>}
+            status="active"
+          />
+        ) : null}
         {reasoningParts.map((part) => {
           if (part.type === "reasoning") {
-            const lines = (part.text ?? "").replace(/\r\n?/g, "\n").split("\n");
+            const reasoningText = part.text ?? "";
+            const isPartStreaming =
+              isThinking || (isStreamingThis && part.state === "streaming");
+            const lines = reasoningText.replace(/\r\n?/g, "\n").split("\n");
             const titleRegex = /^\*\*(.+?)\*\*\s*$/;
 
             type Section = {
@@ -119,16 +136,25 @@ export function AssistantMessageChainOfThought({
               });
             }
 
-            return sections.map((s) => {
+            return sections.map((s, sectionIndex) => {
               const content = s.content.join("\n").trim();
+              const isLastSection = sectionIndex === sections.length - 1;
               return (
                 <ChainOfThoughtStep
-                  key={`${messageId}-cot-${s.title}-${content.slice(0, 32)}`}
+                  key={`${messageId}-cot-${sectionIndex}-${s.title}`}
                   icon={BrainIcon}
-                  label={s.title || t("Reasoning")}
-                  description={content || t("No details")}
+                  label={
+                    isPartStreaming && isLastSection && !content ? (
+                      <Shimmer duration={2}>{s.title || t("Reasoning")}</Shimmer>
+                    ) : (
+                      s.title || t("Reasoning")
+                    )
+                  }
+                  description={
+                    content || (isPartStreaming ? undefined : t("No details"))
+                  }
                   className="whitespace-pre-wrap"
-                  status="complete"
+                  status={isPartStreaming && isLastSection ? "active" : "complete"}
                 />
               );
             });

--- a/src/components/chat/chat-interface-messages.tsx
+++ b/src/components/chat/chat-interface-messages.tsx
@@ -25,6 +25,7 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
+import { Shimmer } from "@/components/ai-elements/shimmer";
 import { AssistantMessage } from "@/components/chat/assistant-message";
 import type { ModelOption } from "@/components/chat/chat-composer";
 import type { GroupedMessage } from "@/hooks/use-chat-branches";
@@ -193,8 +194,16 @@ export function ChatInterfaceMessages({
           );
         })}
         {status === "submitted" && (
-          <div className="min-h-6">
+          <div className="flex min-h-6 items-center gap-2 text-sm text-muted-foreground">
             <Loader />
+            <Shimmer duration={2}>{t("Thinking...")}</Shimmer>
+          </div>
+        )}
+
+        {status === "streaming" && messages.at(-1)?.role === "user" && (
+          <div className="flex min-h-6 items-center gap-2 text-sm text-muted-foreground">
+            <Loader />
+            <Shimmer duration={2}>{t("Thinking...")}</Shimmer>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Fix OpenRouter `providerOptions` shape so reasoning effort is sent as top-level `reasoning.effort` (was nested under a no-op `providerOptions` object).
- Show Thinking UI while streaming before answer text arrives, including OpenAI's encrypted-reasoning wait phase.
- Keep active status for in-progress reasoning steps.

## Test plan
- [ ] Send a message with an OpenAI reasoning model (platform/OpenRouter path) and confirm Thinking appears before the answer.
- [ ] Confirm Thought process content still appears when reasoning summary arrives.
- [ ] Smoke-check Google/xAI via OpenRouter still work with effort selection.
- [ ] BYOK OpenAI Responses path still works with reasoning summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer “Thinking...” indicators while responses are being generated.
  * Added streaming reasoning steps with shimmer effects and improved progress visibility.
  * Empty completed reasoning sections now display “No details.”

* **Bug Fixes**
  * Improved reasoning configuration handling across supported model providers without changing BYOK or direct routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->