### PR TITLE
fix: stream reasoning live and clear typecheck errors

### DIFF
--- a/src/components/ai-elements/chain-of-thought.tsx
+++ b/src/components/ai-elements/chain-of-thought.tsx
@@ -48,10 +48,14 @@ export const ChainOfThought = memo(
 
     const chainOfThoughtContext = useMemo(() => ({ isOpen, setIsOpen }), [isOpen, setIsOpen]);
 
+    // Single Collapsible root: Base UI Panel must live under the same Root as
+    // Trigger. Splitting them into two Roots left content stuck closed.
     return (
       <ChainOfThoughtContext.Provider value={chainOfThoughtContext}>
-        <div className={cn("not-prose w-full space-y-4", className)} {...props}>
-          {children}
+        <div className={cn("not-prose w-full", className)} {...props}>
+          <Collapsible className="w-full space-y-4" onOpenChange={setIsOpen} open={isOpen}>
+            {children}
+          </Collapsible>
         </div>
       </ChainOfThoughtContext.Provider>
     );
@@ -62,24 +66,22 @@ export type ChainOfThoughtHeaderProps = ComponentProps<typeof CollapsibleTrigger
 
 export const ChainOfThoughtHeader = memo(
   ({ className, children, ...props }: ChainOfThoughtHeaderProps) => {
-    const { isOpen, setIsOpen } = useChainOfThought();
+    const { isOpen } = useChainOfThought();
 
     return (
-      <Collapsible onOpenChange={setIsOpen} open={isOpen}>
-        <CollapsibleTrigger
-          className={cn(
-            "flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground",
-            className,
-          )}
-          {...props}
-        >
-          <BrainIcon className="size-4" />
-          <span className="flex-1 text-left">{children ?? "Chain of Thought"}</span>
-          <ChevronDownIcon
-            className={cn("size-4 transition-transform", isOpen ? "rotate-180" : "rotate-0")}
-          />
-        </CollapsibleTrigger>
-      </Collapsible>
+      <CollapsibleTrigger
+        className={cn(
+          "flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground",
+          className,
+        )}
+        {...props}
+      >
+        <BrainIcon className="size-4" />
+        <span className="flex-1 text-left">{children ?? "Chain of Thought"}</span>
+        <ChevronDownIcon
+          className={cn("size-4 transition-transform", isOpen ? "rotate-180" : "rotate-0")}
+        />
+      </CollapsibleTrigger>
     );
   },
 );
@@ -154,24 +156,18 @@ export const ChainOfThoughtSearchResult = memo(
 export type ChainOfThoughtContentProps = ComponentProps<typeof CollapsibleContent>;
 
 export const ChainOfThoughtContent = memo(
-  ({ className, children, ...props }: ChainOfThoughtContentProps) => {
-    const { isOpen } = useChainOfThought();
-
-    return (
-      <Collapsible open={isOpen}>
-        <CollapsibleContent
-          className={cn(
-            "mt-2 space-y-3",
-            "data-closed:fade-out-0 data-closed:slide-out-to-top-2 data-open:slide-in-from-top-2 text-popover-foreground outline-none data-closed:animate-out data-open:animate-in",
-            className,
-          )}
-          {...props}
-        >
-          {children}
-        </CollapsibleContent>
-      </Collapsible>
-    );
-  },
+  ({ className, children, ...props }: ChainOfThoughtContentProps) => (
+    <CollapsibleContent
+      className={cn(
+        "mt-2 space-y-3",
+        "data-closed:fade-out-0 data-closed:slide-out-to-top-2 data-open:slide-in-from-top-2 text-popover-foreground outline-none data-closed:animate-out data-open:animate-in",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </CollapsibleContent>
+  ),
 );
 
 export type ChainOfThoughtImageProps = ComponentProps<"div"> & {

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -7,13 +7,10 @@ import { Button } from "@/components/ui/button";
 import { ButtonGroup, ButtonGroupText } from "@/components/ui/button-group";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
-import { math } from "@streamdown/math";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { createContext, memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
-import { lazyMermaid } from "@/components/chat/streamdown-mermaid-plugin";
+import { streamdownPlugins } from "@/components/chat/streamdown-plugins";
 import { streamdownRemarkPlugins } from "@/components/chat/streamdown-remark-plugins";
 import { streamdownOverrideComponents } from "@/components/chat/streamdown-overrides";
 
@@ -272,8 +269,6 @@ export const MessageBranchPage = ({ className, ...props }: MessageBranchPageProp
 };
 
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
-
-const streamdownPlugins = { cjk, code, math, mermaid: lazyMermaid };
 
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -5,9 +5,6 @@ import type { ComponentProps, ReactNode } from "react";
 import { useControllableState } from "@/lib/base-ui-compat";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
-import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
-import { math } from "@streamdown/math";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import {
   createContext,
@@ -20,7 +17,7 @@ import {
   useState,
 } from "react";
 import { Streamdown } from "streamdown";
-import { lazyMermaid } from "@/components/chat/streamdown-mermaid-plugin";
+import { streamdownPlugins } from "@/components/chat/streamdown-plugins";
 import { streamdownRemarkPlugins } from "@/components/chat/streamdown-remark-plugins";
 
 import { Shimmer } from "./shimmer";
@@ -146,10 +143,15 @@ export type ReasoningTriggerProps = ComponentProps<typeof CollapsibleTrigger> & 
 };
 
 const defaultGetThinkingMessage = (isStreaming: boolean, duration?: number) => {
-  if (isStreaming || duration === 0) {
+  // Only show the live Thinking spinner while the stream is active.
+  // duration === 0 is a completed (very short) run, not still thinking.
+  if (isStreaming) {
     return <Shimmer duration={1}>Thinking...</Shimmer>;
   }
   if (duration === undefined) {
+    return <p>Thought for a few seconds</p>;
+  }
+  if (duration === 0) {
     return <p>Thought for a few seconds</p>;
   }
   return <p>Thought for {duration} seconds</p>;
@@ -189,8 +191,6 @@ export const ReasoningTrigger = memo(
 export type ReasoningContentProps = ComponentProps<typeof CollapsibleContent> & {
   children: string;
 };
-
-const streamdownPlugins = { cjk, code, math, mermaid: lazyMermaid };
 
 export const ReasoningContent = memo(({ className, children, ...props }: ReasoningContentProps) => (
   <CollapsibleContent

--- a/src/components/billing/stripe-checkout-page.tsx
+++ b/src/components/billing/stripe-checkout-page.tsx
@@ -41,6 +41,45 @@ type CheckoutSessionSummary = {
   planId: string | null;
 };
 
+type CheckoutSessionApiResult = {
+  sessionId: string;
+  clientSecret: string | null;
+  status?: string | null;
+  paymentStatus?: string | null;
+  amountTotal: number | null;
+  currency: string | null;
+  mode?: string | null;
+  planId: string | null;
+};
+
+function toCheckoutSessionSummary(result: CheckoutSessionApiResult): CheckoutSessionSummary {
+  const status =
+    result.status === "open" || result.status === "complete" || result.status === "expired"
+      ? result.status
+      : "open";
+  const paymentStatus =
+    result.paymentStatus === "paid" ||
+    result.paymentStatus === "unpaid" ||
+    result.paymentStatus === "no_payment_required"
+      ? result.paymentStatus
+      : null;
+  const mode =
+    result.mode === "subscription" || result.mode === "payment" || result.mode === "setup"
+      ? result.mode
+      : "subscription";
+
+  return {
+    sessionId: result.sessionId,
+    clientSecret: result.clientSecret,
+    status,
+    paymentStatus,
+    amountTotal: result.amountTotal,
+    currency: result.currency,
+    mode,
+    planId: result.planId,
+  };
+}
+
 const checkoutOfferDateFormatter = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",
@@ -914,10 +953,7 @@ export function StripeCheckoutPage(props: StripeCheckoutPageProps) {
         if (!cancelled) {
           dispatchBootstrap({
             type: "success",
-            session: {
-              ...result,
-              status: result.status ?? "open",
-            },
+            session: toCheckoutSessionSummary(result),
             availablePlans: planResult.plans,
             stripeInstance: loadedStripe,
           });

--- a/src/components/chat/assistant-message-parts.tsx
+++ b/src/components/chat/assistant-message-parts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { UIDataTypes, UIMessagePart, UITools } from "ai";
-import { BrainIcon, Globe } from "lucide-react";
+import { Globe } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useExtracted } from "next-intl";
@@ -14,6 +14,11 @@ import {
   ChainOfThoughtStep,
 } from "@/components/ai-elements/chain-of-thought";
 import { Message, MessageContent } from "@/components/ai-elements/message";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "@/components/ai-elements/reasoning";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Source, Sources, SourcesContent, SourcesTrigger } from "@/components/ai-elements/sources";
 import {
@@ -58,199 +63,157 @@ export function AssistantMessageChainOfThought({
 }: AssistantMessageChainOfThoughtProps) {
   const t = useExtracted();
 
-  // OpenAI (via OpenRouter) often streams only encrypted reasoning first and
-  // delivers a visible summary with/just before the final answer. Show a
-  // Thinking placeholder for the whole pre-answer phase so the UI looks like
-  // thought-in-progress, not a blank wait.
+  // OpenAI often streams encrypted tokens first, then visible summary deltas.
+  // Show Thinking only while the chat is still streaming AND the answer text
+  // has not started. Do not key off part.state === "streaming": finish-step can
+  // clear active reasoning without setting state to "done", which left the UI
+  // stuck on Thinking after finish.
   const isThinking = isStreamingThis && !hasTextParts;
+  const textReasoningParts = reasoningParts.filter(
+    (part): part is Extract<UIMessagePart<UIDataTypes, UITools>, { type: "reasoning" }> =>
+      part.type === "reasoning",
+  );
+  const toolParts = reasoningParts.filter(
+    (part) => part.type === "tool-search" || part.type === "tool-browse",
+  );
 
-  if (reasoningParts.length === 0 && !isThinking) {
+  if (textReasoningParts.length === 0 && toolParts.length === 0 && !isThinking) {
     return null;
   }
 
+  const thinkingLabel = (streaming: boolean) =>
+    streaming ? <Shimmer duration={1}>{t("Thinking...")}</Shimmer> : <p>{t("Thought process")}</p>;
+
   return (
-    <ChainOfThought defaultOpen={isThinking || isStreamingThis}>
-      <ChainOfThoughtHeader>
-        {isThinking ? (
-          <Shimmer duration={2}>{t("Thinking...")}</Shimmer>
-        ) : (
-          t("Thought process")
-        )}
-      </ChainOfThoughtHeader>
-      <ChainOfThoughtContent>
-        {reasoningParts.length === 0 && isThinking ? (
-          <ChainOfThoughtStep
-            key={`${messageId}-cot-thinking`}
-            icon={BrainIcon}
-            label={<Shimmer duration={2}>{t("Thinking...")}</Shimmer>}
-            status="active"
-          />
-        ) : null}
-        {reasoningParts.map((part) => {
-          if (part.type === "reasoning") {
-            const reasoningText = part.text ?? "";
-            const isPartStreaming =
-              isThinking || (isStreamingThis && part.state === "streaming");
-            const lines = reasoningText.replace(/\r\n?/g, "\n").split("\n");
-            const titleRegex = /^\*\*(.+?)\*\*\s*$/;
+    <div className="w-full space-y-2">
+      {textReasoningParts.length === 0 && isThinking ? (
+        <Reasoning className="w-full" isStreaming defaultOpen>
+          <ReasoningTrigger getThinkingMessage={thinkingLabel} />
+          <ReasoningContent>{""}</ReasoningContent>
+        </Reasoning>
+      ) : null}
 
-            type Section = {
-              title: string;
-              content: string[];
-            };
-            const sections: Section[] = [];
+      {textReasoningParts.map((part, index) => (
+        <Reasoning
+          key={`${messageId}-reasoning-${index}`}
+          className="w-full"
+          isStreaming={isThinking}
+          // Force open only while still thinking so finish/answer end the spinner.
+          open={isThinking ? true : undefined}
+          defaultOpen
+        >
+          <ReasoningTrigger getThinkingMessage={thinkingLabel} />
+          <ReasoningContent>{part.text ?? ""}</ReasoningContent>
+        </Reasoning>
+      ))}
 
-            let currentTitle: string | null = null;
-            let currentContent: string[] = [];
-
-            const flush = () => {
-              if (currentTitle === null && currentContent.length === 0) return;
-
-              sections.push({
-                title: (currentTitle ?? t("Reasoning")).trim() || t("Reasoning"),
-                content: currentContent,
-              });
-
-              currentTitle = null;
-              currentContent = [];
-            };
-
-            for (const rawLine of lines) {
-              const line = rawLine;
-              const trimmed = line.trim();
-              const m = trimmed.match(titleRegex);
-
-              if (m) {
-                flush();
-                currentTitle = m[1];
-              } else {
-                currentContent.push(line);
+      {toolParts.length > 0 ? (
+        <ChainOfThought defaultOpen={isThinking} open={isThinking ? true : undefined}>
+          <ChainOfThoughtHeader>
+            {isThinking ? (
+              <Shimmer duration={2}>{t("Thinking...")}</Shimmer>
+            ) : (
+              t("Thought process")
+            )}
+          </ChainOfThoughtHeader>
+          <ChainOfThoughtContent>
+            {toolParts.map((part) => {
+              if (part.type === "tool-search") {
+                const isSearching =
+                  part.state !== "output-available" && part.state !== "output-error";
+                const searchResults = isSearchResultArray(part.output) ? part.output : [];
+                const searchKey =
+                  part.toolCallId ??
+                  `${messageId}-search-${part.state}-${searchResults[0]?.url ?? "empty"}`;
+                return (
+                  <ChainOfThoughtStep
+                    key={searchKey}
+                    icon={Globe}
+                    label={
+                      isSearching ? (
+                        <Shimmer duration={2}>{t("Searching...")}</Shimmer>
+                      ) : part.state === "output-error" ? (
+                        t("Search failed")
+                      ) : (
+                        t("Found {count} results", {
+                          count: searchResults.length.toString(),
+                        })
+                      )
+                    }
+                    status={isSearching ? "active" : "complete"}
+                  >
+                    {searchResults.length > 0 && (
+                      <ChainOfThoughtSearchResults>
+                        {searchResults.map((result) => {
+                          const displayUrl = getSafeDisplayUrl(result.url);
+                          return (
+                            <Link
+                              key={result.url}
+                              href={displayUrl?.href ?? "#"}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              <ChainOfThoughtSearchResult>
+                                <Globe className="size-3" />
+                                {displayUrl?.hostname ?? t("Unknown")}
+                              </ChainOfThoughtSearchResult>
+                            </Link>
+                          );
+                        })}
+                      </ChainOfThoughtSearchResults>
+                    )}
+                  </ChainOfThoughtStep>
+                );
               }
-            }
-            flush();
 
-            if (sections.length === 0) {
-              sections.push({
-                title: t("Reasoning"),
-                content: [],
-              });
-            }
+              if (part.type === "tool-browse") {
+                const isBrowsing =
+                  part.state !== "output-available" && part.state !== "output-error";
+                const browseOutput = isBrowseToolOutput(part.output) ? part.output : null;
+                const browseInput = isBrowseToolInput(part.input) ? part.input : null;
+                const browseUrl = browseOutput?.url ?? browseInput?.url ?? "";
+                const displayUrl = getSafeDisplayUrl(browseUrl);
+                const browseKey =
+                  part.toolCallId ?? `${messageId}-browse-${part.state}-${browseUrl || "empty"}`;
+                const failed =
+                  part.state === "output-error" ||
+                  Boolean(browseOutput?.error && !browseOutput.content);
 
-            return sections.map((s, sectionIndex) => {
-              const content = s.content.join("\n").trim();
-              const isLastSection = sectionIndex === sections.length - 1;
-              return (
-                <ChainOfThoughtStep
-                  key={`${messageId}-cot-${sectionIndex}-${s.title}`}
-                  icon={BrainIcon}
-                  label={
-                    isPartStreaming && isLastSection && !content ? (
-                      <Shimmer duration={2}>{s.title || t("Reasoning")}</Shimmer>
-                    ) : (
-                      s.title || t("Reasoning")
-                    )
-                  }
-                  description={
-                    content || (isPartStreaming ? undefined : t("No details"))
-                  }
-                  className="whitespace-pre-wrap"
-                  status={isPartStreaming && isLastSection ? "active" : "complete"}
-                />
-              );
-            });
-          }
-
-          if (part.type === "tool-search") {
-            const isSearching = part.state !== "output-available" && part.state !== "output-error";
-            const searchResults = isSearchResultArray(part.output) ? part.output : [];
-            const searchKey =
-              part.toolCallId ??
-              `${messageId}-search-${part.state}-${searchResults[0]?.url ?? "empty"}`;
-            return (
-              <ChainOfThoughtStep
-                key={searchKey}
-                icon={Globe}
-                label={
-                  isSearching ? (
-                    <Shimmer duration={2}>{t("Searching...")}</Shimmer>
-                  ) : part.state === "output-error" ? (
-                    t("Search failed")
-                  ) : (
-                    t("Found {count} results", {
-                      count: searchResults.length.toString(),
-                    })
-                  )
-                }
-                status={isSearching ? "active" : "complete"}
-              >
-                {searchResults.length > 0 && (
-                  <ChainOfThoughtSearchResults>
-                    {searchResults.map((result) => {
-                      const displayUrl = getSafeDisplayUrl(result.url);
-                      return (
-                        <Link
-                          key={result.url}
-                          href={displayUrl?.href ?? "#"}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
+                return (
+                  <ChainOfThoughtStep
+                    key={browseKey}
+                    icon={Globe}
+                    label={
+                      isBrowsing ? (
+                        <Shimmer duration={2}>{t("Opening page...")}</Shimmer>
+                      ) : failed ? (
+                        t("Failed to open page")
+                      ) : (
+                        t("Opened page")
+                      )
+                    }
+                    status={isBrowsing ? "active" : "complete"}
+                  >
+                    {displayUrl && (
+                      <ChainOfThoughtSearchResults>
+                        <Link href={displayUrl.href} target="_blank" rel="noreferrer">
                           <ChainOfThoughtSearchResult>
                             <Globe className="size-3" />
-                            {displayUrl?.hostname ?? t("Unknown")}
+                            {browseOutput?.title?.trim() || displayUrl.hostname}
                           </ChainOfThoughtSearchResult>
                         </Link>
-                      );
-                    })}
-                  </ChainOfThoughtSearchResults>
-                )}
-              </ChainOfThoughtStep>
-            );
-          }
+                      </ChainOfThoughtSearchResults>
+                    )}
+                  </ChainOfThoughtStep>
+                );
+              }
 
-          if (part.type === "tool-browse") {
-            const isBrowsing = part.state !== "output-available" && part.state !== "output-error";
-            const browseOutput = isBrowseToolOutput(part.output) ? part.output : null;
-            const browseInput = isBrowseToolInput(part.input) ? part.input : null;
-            const browseUrl = browseOutput?.url ?? browseInput?.url ?? "";
-            const displayUrl = getSafeDisplayUrl(browseUrl);
-            const browseKey =
-              part.toolCallId ?? `${messageId}-browse-${part.state}-${browseUrl || "empty"}`;
-            const failed =
-              part.state === "output-error" ||
-              Boolean(browseOutput?.error && !browseOutput.content);
-
-            return (
-              <ChainOfThoughtStep
-                key={browseKey}
-                icon={Globe}
-                label={
-                  isBrowsing ? (
-                    <Shimmer duration={2}>{t("Opening page...")}</Shimmer>
-                  ) : failed ? (
-                    t("Failed to open page")
-                  ) : (
-                    t("Opened page")
-                  )
-                }
-                status={isBrowsing ? "active" : "complete"}
-              >
-                {displayUrl && (
-                  <ChainOfThoughtSearchResults>
-                    <Link href={displayUrl.href} target="_blank" rel="noreferrer">
-                      <ChainOfThoughtSearchResult>
-                        <Globe className="size-3" />
-                        {browseOutput?.title?.trim() || displayUrl.hostname}
-                      </ChainOfThoughtSearchResult>
-                    </Link>
-                  </ChainOfThoughtSearchResults>
-                )}
-              </ChainOfThoughtStep>
-            );
-          }
-          return null;
-        })}
-      </ChainOfThoughtContent>
-    </ChainOfThought>
+              return null;
+            })}
+          </ChainOfThoughtContent>
+        </ChainOfThought>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/components/chat/streamdown-plugins.ts
+++ b/src/components/chat/streamdown-plugins.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import type { PluginConfig } from "streamdown";
+import { cjk } from "@streamdown/cjk";
+import { code } from "@streamdown/code";
+import { math } from "@streamdown/math";
+import { lazyMermaid } from "@/components/chat/streamdown-mermaid-plugin";
+
+/**
+ * Shared Streamdown plugin map.
+ *
+ * Cast through PluginConfig: @streamdown/code and streamdown can resolve
+ * different shiki language unions in the same install, which otherwise fails
+ * structural typing on `plugins`.
+ */
+export const streamdownPlugins = {
+  cjk,
+  code,
+  math,
+  mermaid: lazyMermaid,
+} as PluginConfig;


### PR DESCRIPTION
## Summary
- Stream reasoning text live via the Reasoning component (force-open while pre-answer)
- End Thinking after answer text starts / stream settles (no longer stuck after finish)
- Fix ChainOfThought Collapsible so content actually expands under Base UI
- Fix typecheck: Streamdown plugin shiki mismatch + Stripe paymentStatus union

## Test plan
- [ ] OpenAI reasoning model: Thinking shows, reasoning deltas stream, finish stops Thinking
- [ ] Answer text starts → label becomes Thought process
- [ ] `bun run typecheck` and `bun run lint` pass