### PR TITLE
fix: make chat token streaming progressive end-to-end

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,9 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   reactCompiler: true,
   poweredByHeader: false,
+  // Gzip/brotli compression buffers response bodies and breaks SSE token
+  // streaming (UI only paints after the full model response). Keep raw chunks.
+  compress: false,
   // Tree-shake large icon/date packages more aggressively
   experimental: {
     optimizePackageImports: [
@@ -120,6 +123,14 @@ const nextConfig: NextConfig = {
       {
         source: "/api/:path*",
         headers: [{ key: "Cache-Control", value: "private, no-cache, no-store" }],
+      },
+      {
+        source: "/api/chat",
+        headers: [
+          { key: "Cache-Control", value: "no-cache, no-transform" },
+          { key: "X-Accel-Buffering", value: "no" },
+          { key: "Connection", value: "keep-alive" },
+        ],
       },
     ];
   },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,8 +1,6 @@
 import {
   consumeStream,
   convertToModelMessages,
-  createUIMessageStream,
-  createUIMessageStreamResponse,
   generateId,
   safeValidateUIMessages,
   stepCountIs,
@@ -10,7 +8,6 @@ import {
   type ModelMessage,
   type SystemModelMessage,
   type UIMessage,
-  type UIMessageChunk,
 } from "ai";
 import { headers } from "next/headers";
 import { after, NextResponse } from "next/server";
@@ -47,6 +44,11 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { addOpenRouterCacheControl, ChatRouteError, resolveChatModelContext } from "./_lib/model";
 import { buildChatSystemPrompt } from "./_lib/prompt";
 import { ChatRequestSchema, setPendingState } from "./_lib/schema";
+
+// Ensure this route is never statically optimized / buffered by the framework.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
 
 function getErrorMessage(error: unknown): string | undefined {
   if (typeof error === "string") {
@@ -537,59 +539,39 @@ export async function POST(req: Request) {
     throw new Error(formatChatStreamError(error, baseModel));
   }
 
-  // Client path is a single unblocked merge (no tee). A second persistence
-  // branch used to backpressure the SSE via tee() so the UI only painted
-  // after the model finished. Final DB write happens in onFinish via after().
-  const stream = createUIMessageStream<UIMessage>({
+  // Use the SDK's direct UI stream response path (no createUIMessageStream
+  // push-buffer / custom tee). This is the well-tested progressive SSE path.
+  return result.toUIMessageStreamResponse({
     originalMessages: messages,
-    execute: async ({ writer }) => {
-      try {
-        writer.write({
-          type: "start",
-          messageId: responseMessageId,
-        });
-
-        const uiStream = result.toUIMessageStream<UIMessage>({
-          sendReasoning: true,
-          sendSources: true,
-          sendStart: false,
-          onError: (error) => formatChatStreamError(error, baseModel),
-        });
-
-        const clientStream = uiStream.pipeThrough(
-          new TransformStream<UIMessageChunk, UIMessageChunk>({
-            transform(chunk, controller) {
-              // Enqueue first; never await before this.
-              controller.enqueue(chunk);
-
-              if (
-                chunk.type === "text-start" ||
-                chunk.type === "text-delta" ||
-                chunk.type === "reasoning-start" ||
-                chunk.type === "reasoning-delta" ||
-                chunk.type === "tool-input-start" ||
-                chunk.type === "tool-input-available" ||
-                chunk.type === "tool-output-available" ||
-                chunk.type === "file" ||
-                chunk.type === "source-url"
-              ) {
-                hasAssistantOutput = true;
-              }
-            },
-          }),
-        );
-
-        writer.merge(clientStream);
-      } catch (error) {
-        await rollbackPendingAssistantState();
-        await refundConsumedUsage();
-        clearGenerationLock();
-        throw new Error(formatChatStreamError(error, baseModel));
-      }
+    generateMessageId: () => responseMessageId,
+    sendReasoning: true,
+    sendSources: true,
+    sendStart: true,
+    sendFinish: true,
+    onError: (error) => formatChatStreamError(error, baseModel),
+    // Keep the Node process alive until the stream is fully consumed without
+    // blocking the client-facing branch of the SSE tee more than necessary.
+    consumeSseStream: consumeStream,
+    headers: {
+      // Prevent proxies / gzip layers from buffering the full body.
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no",
+      Connection: "keep-alive",
     },
-    onFinish: async ({ messages: updatedMessages, isAborted }) => {
-      // Return immediately so the SSE can close. Heavy DB/title/usage work
-      // must not sit on the stream flush path.
+    onFinish: ({ messages: updatedMessages, isAborted, responseMessage }) => {
+      const assistantParts = responseMessage?.parts ?? [];
+      hasAssistantOutput = assistantParts.some((part) => {
+        if (part.type === "text" || part.type === "reasoning") {
+          return Boolean(part.text?.trim());
+        }
+        return (
+          part.type === "file" ||
+          part.type === "source-url" ||
+          part.type.startsWith("tool-")
+        );
+      });
+
+      // Heavy work off the stream flush path so the HTTP response can end ASAP.
       after(async () => {
         try {
           if (!(await ownsCurrentGeneration())) {
@@ -659,10 +641,5 @@ export async function POST(req: Request) {
         }
       });
     },
-  });
-
-  return createUIMessageStreamResponse({
-    stream,
-    consumeSseStream: consumeStream,
   });
 }

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -270,6 +270,8 @@ export const MessageBranchPage = ({ className, ...props }: MessageBranchPageProp
 
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
+// Do not use a custom memo comparator: React Compiler + streaming text updates
+// need default prop comparison so growing `children` always re-renders.
 export const MessageResponse = memo(
   ({ className, mode = "streaming", ...props }: MessageResponseProps) => (
     <Streamdown
@@ -281,8 +283,6 @@ export const MessageResponse = memo(
       {...props}
     />
   ),
-  (prevProps, nextProps) =>
-    prevProps.children === nextProps.children && prevProps.mode === nextProps.mode,
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/src/components/chat/assistant-message.tsx
+++ b/src/components/chat/assistant-message.tsx
@@ -130,7 +130,9 @@ export function AssistantMessage({
       {textParts.map((part, i) => (
         <Message key={`${message.id}-text-${i}`} from={message.role}>
           <MessageContent>
-            <MessageResponse>{part.text}</MessageResponse>
+            <MessageResponse mode={isStreamingThis ? "streaming" : "static"}>
+              {part.text}
+            </MessageResponse>
           </MessageContent>
           {i === textParts.length - 1 && state.showActions && (
             <MessageActions>

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -6,7 +6,7 @@ import type { FileUIPart, UIMessage } from "ai";
 import { DefaultChatTransport } from "ai";
 import dynamic from "next/dynamic";
 import { useExtracted } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AdSenseSlot } from "@/components/adsense-slot";
 import { ArtifactPreviewProvider } from "@/components/chat/artifact-preview-context";
 import { ChatComposer, type ComposerMessage } from "@/components/chat/chat-composer";
@@ -181,16 +181,24 @@ export function ChatInterface({
     image: imageMode,
     id,
   };
-  const transport = new DefaultChatTransport({
-    body: {
-      id,
-    },
-  });
+  // Stable transport instance — recreating DefaultChatTransport every render
+  // is unnecessary and has caused stale request plumbing in the past.
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/chat",
+        body: { id },
+      }),
+    [id],
+  );
 
   const { messages, sendMessage, regenerate, setMessages, status, error, stop } = useChat({
     id,
     messages: initialMessages,
     transport,
+    // Do not throttle UI message updates — throttling makes tokens appear in bursts
+    // or only after the stream settles.
+    experimental_throttle: undefined,
   });
 
   const { handleRegenerate, groupedMessages } = useChatBranches({


### PR DESCRIPTION
## Summary
Tokens still only appeared after the full model response. This PR attacks every remaining layer that can cause that.

### Server
- Replace custom `createUIMessageStream` + merge path with SDK `toUIMessageStreamResponse`
- Finalize DB/title/usage via `after()` so flush is not blocked
- Route is `force-dynamic` / `nodejs` / `maxDuration=300`
- Response headers: `Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`

### Next.js
- `compress: false` — gzip/brotli buffering is a common cause of SSE only flushing at the end
- Extra headers on `/api/chat`

### Client
- Stable `DefaultChatTransport` via `useMemo`
- No `experimental_throttle` on message updates
- Remove custom `MessageResponse` memo comparator that could skip streaming text updates
- Explicit Streamdown `mode="streaming"` while the assistant is streaming

## Test plan
- [ ] DevTools → Network → `/api/chat`: SSE `text-delta` events arrive while the request is still open
- [ ] UI text grows during the request (not only on finish)
- [ ] Reasoning (if any) appears during the request
- [ ] New chat title still generates after finish
- [ ] Stop / regenerate still works