### PR TITLE
fix: remove dynamic route config incompatible with cacheComponents

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -45,8 +45,7 @@ import { addOpenRouterCacheControl, ChatRouteError, resolveChatModelContext } fr
 import { buildChatSystemPrompt } from "./_lib/prompt";
 import { ChatRequestSchema, setPendingState } from "./_lib/schema";
 
-// Ensure this route is never statically optimized / buffered by the framework.
-export const dynamic = "force-dynamic";
+// Note: `export const dynamic` is incompatible with nextConfig.cacheComponents.
 export const runtime = "nodejs";
 export const maxDuration = 300;
 


### PR DESCRIPTION
## Summary
- Remove `export const dynamic = \"force-dynamic\"` from `/api/chat` — not compatible with `nextConfig.cacheComponents`.
- Keep `runtime` and `maxDuration`.