### PR TITLE
Promote canary: fix affiliate invite 0.0.0.0 redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,9 @@ FROM node:22-bookworm-slim AS runner
 WORKDIR /app
 
 # Dokploy / Traefik reach the container on this port.
-# HOSTNAME=0.0.0.0 is required so the proxy can connect.
+# HOSTNAME=0.0.0.0 is only the listen bind address (not the public site URL).
+# Never set NEXT_PUBLIC_BETTER_AUTH_URL to http://0.0.0.0:3000 — use the real
+# public origin (e.g. https://deniai.app) at build time.
 ENV PORT=3000 \
   HOSTNAME=0.0.0.0 \
   NEXT_TELEMETRY_DISABLED=1 \

--- a/SETUP.md
+++ b/SETUP.md
@@ -310,6 +310,7 @@ Any host that can run a Next.js standalone Node server (Railway, Render, Fly.io,
 | ----------------------------- | ------------------------------------------------------------- |
 | Env validation errors on boot | Missing keys in `src/env.ts`; empty optional strings are OK   |
 | OAuth redirect mismatch       | Callback URLs must match `NEXT_PUBLIC_BETTER_AUTH_URL`        |
+| Affiliate link is `0.0.0.0`   | Set `NEXT_PUBLIC_BETTER_AUTH_URL` to the **public** HTTPS origin (not Docker `HOSTNAME=0.0.0.0`). Rebuild so `NEXT_PUBLIC_*` is re-inlined. `/invite/*` redirects use that origin. |
 | DB migrate fails              | Correct `DATABASE_URL`; use `db:migrate:dev` for local        |
 | Stripe checkout broken        | Publishable key + webhook secret; Stripe CLI for local        |
 | Search / browse tools fail    | Valid `BRAVE_SEARCH_API_KEY`                                  |

--- a/src/app/invite/[code]/route.ts
+++ b/src/app/invite/[code]/route.ts
@@ -2,12 +2,16 @@ import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { affiliateProfile } from "@/db/schema";
 import { db } from "@/db/drizzle";
+import { env } from "@/env";
 import { AFFILIATE_COOKIE_NAME, normalizeAffiliateCode } from "@/lib/affiliate";
 
-export async function GET(request: Request, { params }: { params: Promise<{ code: string }> }) {
+export async function GET(_request: Request, { params }: { params: Promise<{ code: string }> }) {
   const { code } = await params;
   const normalizedCode = normalizeAffiliateCode(code);
-  const destination = new URL("/auth/sign-up", request.url);
+  // Always redirect against the public app origin. In Docker, Next binds with
+  // HOSTNAME=0.0.0.0 so `request.url` can become http://0.0.0.0:3000 when the
+  // reverse proxy does not forward Host correctly — never use that for public URLs.
+  const destination = new URL("/auth/sign-up", env.NEXT_PUBLIC_BETTER_AUTH_URL);
 
   if (!normalizedCode) {
     destination.searchParams.set("referral", "invalid");

--- a/src/env.ts
+++ b/src/env.ts
@@ -50,7 +50,21 @@ export const env = createEnv({
     UPLOADTHING_TOKEN: z.string().min(1).optional(),
   },
   client: {
-    NEXT_PUBLIC_BETTER_AUTH_URL: z.url(),
+    /**
+     * Public app origin (OAuth callbacks, affiliate invite redirects, emails).
+     * Must be the real public URL (e.g. https://deniai.app) — never the Docker
+     * bind address (0.0.0.0) or an internal container hostname.
+     */
+    NEXT_PUBLIC_BETTER_AUTH_URL: z
+      .url()
+      .refine((value) => {
+        try {
+          const host = new URL(value).hostname;
+          return host !== "0.0.0.0" && host !== "::" && host !== "[::]";
+        } catch {
+          return false;
+        }
+      }, "NEXT_PUBLIC_BETTER_AUTH_URL must be a public origin (not 0.0.0.0)"),
     NEXT_PUBLIC_BILLING_DISABLED: z.string().min(1).optional(),
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string().min(1).optional(),
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().min(1),


### PR DESCRIPTION
## Summary
- Affiliate /invite/* redirects now use NEXT_PUBLIC_BETTER_AUTH_URL instead of equest.url.
- Prevents Docker HOSTNAME=0.0.0.0 from leaking into sign-up referral URLs.
- Reject 