### PR TITLE
Promote canary: edu domain allowlist + magic-link Turnstile

### DIFF
--- a/src/components/auth/magic-link.tsx
+++ b/src/components/auth/magic-link.tsx
@@ -5,6 +5,7 @@ import {
   type MagicLinkAuthClient,
   useAuth,
   useAuthPlugin,
+  useFetchOptions,
   useSignInMagicLink,
 } from "@better-auth-ui/react";
 import { useIsMutating } from "@tanstack/react-query";
@@ -55,12 +56,16 @@ export function MagicLink({ className, socialLayout, socialPosition = "bottom" }
     Link,
   } = useAuth();
   const { localization: magicLinkLocalization } = useAuthPlugin(magicLinkPlugin);
+  const { fetchOptions, resetFetchOptions } = useFetchOptions();
 
   const [email, setEmail] = useState("");
 
   const { mutate: signInMagicLink, isPending: signInMagicLinkPending } = useSignInMagicLink(
     authClient as MagicLinkAuthClient,
     {
+      onError: () => {
+        resetFetchOptions();
+      },
       onSuccess: () => {
         setEmail("");
         toast.success(magicLinkLocalization.magicLinkSent);
@@ -76,13 +81,19 @@ export function MagicLink({ className, socialLayout, socialPosition = "bottom" }
   });
   const isPending = signInMutating + signUpMutating > 0;
 
+  const Captcha = plugins.find((plugin) => plugin.captchaComponent)?.captchaComponent;
+
   const [fieldErrors, setFieldErrors] = useState<{
     email?: string;
   }>({});
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    signInMagicLink({ email, callbackURL: `${baseURL}${redirectTo}` });
+    signInMagicLink({
+      email,
+      callbackURL: `${baseURL}${redirectTo}`,
+      fetchOptions,
+    });
   };
 
   const showSeparator = socialProviders && socialProviders.length > 0;
@@ -144,6 +155,8 @@ export function MagicLink({ className, socialLayout, socialPosition = "bottom" }
 
                 <FieldError>{fieldErrors.email}</FieldError>
               </Field>
+
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
               <div className="flex flex-col gap-3">
                 <Button type="submit" disabled={isPending}>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,7 +28,7 @@ import { cancelPersonalSubscription, updateTeamSeatCount } from "@/lib/team-bill
 const emailEnabled = isEmailConfigured();
 
 const EMAIL_DOMAIN_NOT_ALLOWED_MESSAGE =
-  "Please use a major email provider (Gmail, Outlook, iCloud, Proton, etc.) or an educational address (.edu / .ac.*). To request adding another email domain, contact contact@deniai.app.";
+  "Please use a major email provider (Gmail, Outlook, iCloud, Proton, etc.) or a restricted educational address (e.g. .edu, .ac.jp, .ac.uk, .edu.au). To request adding another email domain, contact contact@deniai.app.";
 
 function assertAllowedSignupEmail(email: string) {
   if (!isAllowedSignupEmail(email)) {
@@ -146,6 +146,13 @@ export const auth = betterAuth({
     captcha({
       provider: "cloudflare-turnstile",
       secretKey: env.TURNSTILE_SECRET_KEY,
+      // Include defaults + magic-link request (not /magic-link/verify — email click).
+      endpoints: [
+        "/sign-up/email",
+        "/sign-in/email",
+        "/request-password-reset",
+        "/sign-in/magic-link",
+      ],
     }),
     bearer(),
     ...(emailEnabled

--- a/src/lib/auth/captcha-plugin.ts
+++ b/src/lib/auth/captcha-plugin.ts
@@ -9,7 +9,7 @@ const TurnstileCaptcha = dynamic(
 
 /**
  * Registers Cloudflare Turnstile for better-auth-ui forms
- * (sign-in, sign-up, forgot-password, set-password).
+ * (sign-in, sign-up, forgot-password, magic-link).
  */
 export const captchaPlugin = () =>
   coreCaptchaPlugin({

--- a/src/lib/email-domain-policy.ts
+++ b/src/lib/email-domain-policy.ts
@@ -3,8 +3,9 @@
  *
  * Allowlist model:
  *  1. Known major consumer mail providers (exact domain match)
- *  2. Educational domains (.edu, .ac.*, .edu.*, .ed.jp, …) with
- *     spam-prone country codes excluded
+ *  2. Educational domains only under TLDs / SLDs with **restricted
+ *     registration** (real schools / universities), not open `.edu.<cc>`
+ *     namespaces that are routinely sold as throwaway mail
  *
  * OAuth (Google / GitHub) is not gated by this module — those identities
  * are already provider-verified. Apply only on email-based registration
@@ -103,76 +104,36 @@ export const ALLOWED_EMAIL_PROVIDERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Country codes where `.edu.<cc>` / `.ac.<cc>` are frequently abused for
- * disposable / mass sign-ups. Pure US `.edu` (no country suffix) is always
- * allowed and is not affected by this list.
+ * Educational domain suffixes with restricted registration (institutions only).
  *
- * Keep this list focused on observed abuse rather than blocking every
- * developing-country academic domain.
+ * Match when `domain === suffix` or `domain.endsWith("." + suffix)`.
+ * Open / high-abuse namespaces (e.g. `.edu.kg`, bare `.ac` Ascension TLD,
+ * most `.edu.<cc>` without real eligibility checks) are intentionally omitted.
+ *
+ * Add a suffix here only when the registry limits names to real schools.
  */
-export const BLOCKED_EDU_COUNTRY_CODES: ReadonlySet<string> = new Set([
-  // Latin America (high volume of fake school domains in abuse feeds)
-  "co", // Colombia — e.g. *.edu.co spam
-  "br",
-  "mx",
-  "pe",
-  "ar",
-  "cl",
-  "ec",
-  "bo",
-  "py",
-  "uy",
-  "ve",
-  "do",
-  "gt",
-  "hn",
-  "sv",
-  "ni",
-  "cr",
-  "pa",
-  // South / Southeast Asia
-  "vn",
-  "ph",
-  "pk",
-  "in",
-  "bd",
-  "id",
-  "lk",
-  "np",
-  "mm",
-  "kh",
-  "la",
-  "my",
-  "th",
-  // Africa / Middle East (common throwaway edu patterns)
-  "ng",
-  "eg",
-  "ke",
-  "gh",
-  "et",
-  "tz",
-  "ug",
-  "za",
-  "dz",
-  "ma",
-  "tn",
-  "iq",
-  "ir",
-  "sy",
-  "af",
-  "sd",
-  "ye",
-  // Other high-abuse
-  "cn",
-  "ru",
-  "ua",
-  "tr",
-  "by",
-  "kz",
-]);
-
-/** Educational second-level labels we recognize (before country / as TLD). */
-const EDU_LABELS = new Set(["edu", "ac", "ed", "sch"]);
+export const ALLOWED_EDU_DOMAIN_SUFFIXES: readonly string[] = [
+  // United States — sponsored gTLD, eligibility-restricted
+  "edu",
+  // Japan — JPRS academic / school namespaces
+  "ac.jp",
+  "ed.jp",
+  // United Kingdom — JANET academic / school
+  "ac.uk",
+  "sch.uk",
+  // Australia — auDA education eligibility
+  "edu.au",
+  // New Zealand — academic
+  "ac.nz",
+  // South Korea — academic
+  "ac.kr",
+  // Taiwan — education
+  "edu.tw",
+  // Singapore — education
+  "edu.sg",
+  // Hong Kong — education
+  "edu.hk",
+];
 
 export function extractEmailDomain(email: string): string | null {
   const trimmed = email.trim().toLowerCase();
@@ -184,35 +145,24 @@ export function extractEmailDomain(email: string): string | null {
   return domain;
 }
 
+function domainMatchesSuffix(domain: string, suffix: string): boolean {
+  return domain === suffix || domain.endsWith(`.${suffix}`);
+}
+
 /**
- * Educational domain check.
- * - `school.edu`, `sub.school.edu` → allowed (US-style .edu TLD)
- * - `school.ac.jp`, `school.edu.au` → allowed unless country is blocked
- * - `school.ed.jp` → allowed (Japan K-12 style)
- * - `school.edu.co`, `school.edu.vn` → blocked via BLOCKED_EDU_COUNTRY_CODES
+ * Educational domain check (restricted-registration allowlist only).
+ * - `mit.edu`, `cs.stanford.edu` → allowed (US `.edu`)
+ * - `u-tokyo.ac.jp`, `school.ed.jp` → allowed
+ * - `ox.ac.uk`, `uni.edu.au` → allowed
+ * - `cmuk.edu.kg`, `foo.edu.co`, bare `something.ac` → denied
  */
 export function isAllowedEducationalDomain(domain: string): boolean {
   const d = domain.toLowerCase();
   const labels = d.split(".").filter(Boolean);
+  // Need at least school.edu or school.ac.jp
   if (labels.length < 2) return false;
 
-  const tld = labels[labels.length - 1]!;
-
-  // Pure academic TLD: example.edu
-  if (tld === "edu" || tld === "ac") {
-    return true;
-  }
-
-  // Two-part academic: example.ac.jp / example.edu.au / example.ed.jp / example.sch.uk
-  if (labels.length >= 3) {
-    const sld = labels[labels.length - 2]!;
-    const country = tld;
-    if (country.length === 2 && EDU_LABELS.has(sld)) {
-      return !BLOCKED_EDU_COUNTRY_CODES.has(country);
-    }
-  }
-
-  return false;
+  return ALLOWED_EDU_DOMAIN_SUFFIXES.some((suffix) => domainMatchesSuffix(d, suffix));
 }
 
 export function isAllowedEmailProviderDomain(domain: string): boolean {


### PR DESCRIPTION
## Summary
- Educational email signup is now an allowlist of restricted-registration suffixes only (e.g. .edu, .ac.jp, .ac.uk, .edu.au) — blocks abuse domains like *.edu.kg.
- Magic-link sign-in requires Cloudflare Turnstile (server endpoint + UI widget).

## Test plan
- [ ] Sign-up with user@cmuk.edu.kg is rejected
- [ ] Sign-up with user@mit.edu / user@u-tokyo.ac.jp still works
- [ ] Magic-link form shows Turnstile; submit without token fails
- [ ] Magic-link with completed Turnstile sends email