### PR TITLE
Promote canary: free model limits and signup email policy

### DIFF
--- a/src/app/api/chat/_lib/model.ts
+++ b/src/app/api/chat/_lib/model.ts
@@ -10,7 +10,7 @@ import { db } from "@/db/drizzle";
 import { providerKey, providerSetting } from "@/db/schema";
 import { env } from "@/env";
 import { decryptFromB64 } from "@/lib/crypto";
-import { models, resolveReasoningEffort } from "@/lib/constants";
+import { isFreePlanModel, models, resolveReasoningEffort } from "@/lib/constants";
 import { assertSafePublicHttpUrl } from "@/lib/network-security";
 import { createDeniOpenRouter } from "@/lib/openrouter-provider";
 import { getUsageSummary, type UsageCategory, UsageLimitError } from "@/lib/usage";
@@ -184,32 +184,52 @@ export async function resolveChatModelContext({
   const isPremiumModel = Boolean(selectedModel.premium);
   // Pro mode always bills against premium quota (even when the base model is basic).
   const usageCategory: UsageCategory = isPremiumModel || useProMode ? "premium" : "basic";
+  const modelAllowedOnFreePlan = isFreePlanModel(selectedModel.value);
 
-  if (isAnonymous && usageCategory === "premium") {
-    throw new ChatRouteError(403, {
-      error: useProMode
-        ? "Pro mode is not available for guest sessions."
-        : "Premium models are not available for guest sessions.",
-    });
-  }
+  // Free plan / guest sessions are limited to the free-plan model allowlist.
+  // Paid tiers unlock the full catalog. Check tier even for BYOK so free users
+  // cannot bypass the allowlist with their own keys.
+  // Usage limits still apply for non-BYOK traffic.
+  const needsUsageSummary = !useByok || !modelAllowedOnFreePlan;
 
-  if (!useByok) {
+  if (needsUsageSummary) {
     try {
       const usageSummary = await getUsageSummary({ userId, isAnonymous });
-      const categoryUsage = usageSummary.usage.find((usage) => usage.category === usageCategory);
-      usageUnit = categoryUsage?.unit ?? "requests";
-      const isLimitReached =
-        categoryUsage?.remaining !== null &&
-        categoryUsage?.remaining !== undefined &&
-        categoryUsage.remaining <= 0;
 
-      if (isLimitReached && !usageSummary.maxModeEnabled) {
-        throw new UsageLimitError(
-          "You've hit the usage limit for your plan.",
-          usageSummary.maxModeEligible,
-        );
+      if (!modelAllowedOnFreePlan && (isAnonymous || usageSummary.tier === "free")) {
+        throw new ChatRouteError(403, {
+          error:
+            "This model is not available on the Free plan. Upgrade to Plus or higher to use it.",
+        });
+      }
+
+      if (isAnonymous && usageCategory === "premium") {
+        throw new ChatRouteError(403, {
+          error: useProMode
+            ? "Pro mode is not available for guest sessions."
+            : "Premium models are not available for guest sessions.",
+        });
+      }
+
+      if (!useByok) {
+        const categoryUsage = usageSummary.usage.find((usage) => usage.category === usageCategory);
+        usageUnit = categoryUsage?.unit ?? "requests";
+        const isLimitReached =
+          categoryUsage?.remaining !== null &&
+          categoryUsage?.remaining !== undefined &&
+          categoryUsage.remaining <= 0;
+
+        if (isLimitReached && !usageSummary.maxModeEnabled) {
+          throw new UsageLimitError(
+            "You've hit the usage limit for your plan.",
+            usageSummary.maxModeEligible,
+          );
+        }
       }
     } catch (error) {
+      if (error instanceof ChatRouteError) {
+        throw error;
+      }
       if (error instanceof UsageLimitError) {
         throw new ChatRouteError(402, {
           error: error.message,
@@ -220,6 +240,11 @@ export async function resolveChatModelContext({
       console.error("Failed to check usage", error);
       throw new ChatRouteError(500, { error: "Unable to check usage" });
     }
+  } else if (isAnonymous && usageCategory === "premium") {
+    // BYOK path with a free-plan model + Pro mode: still block guests.
+    throw new ChatRouteError(403, {
+      error: "Pro mode is not available for guest sessions.",
+    });
   }
 
   // OpenRouter exposes GPT-5.6 Pro as `*-pro`. voids.top does not — keep base id there.

--- a/src/components/auth/sign-up.tsx
+++ b/src/components/auth/sign-up.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FieldDescription, FieldGroup, FieldSeparator } from "@/components/ui/field";
 import { Spinner } from "@/components/ui/spinner";
+import { checkSignupEmail, signupEmailDenialMessage } from "@/lib/email-domain-policy";
 import { cn } from "@/lib/utils";
 import { ProviderButtons, type SocialLayout } from "./provider-buttons";
 import { SignUpFormFields } from "./sign-up-form-fields";
@@ -105,6 +106,16 @@ export function SignUp({ className, socialLayout, socialPosition = "bottom" }: S
       toast.error(localization.auth.passwordsDoNotMatch);
       setPassword("");
       setConfirmPassword("");
+      return;
+    }
+
+    const emailPolicy = checkSignupEmail(email);
+    if (!emailPolicy.ok) {
+      toast.error(signupEmailDenialMessage(emailPolicy.reason));
+      setFieldErrors((current) => ({
+        ...current,
+        email: signupEmailDenialMessage(emailPolicy.reason),
+      }));
       return;
     }
 

--- a/src/components/chat/home.tsx
+++ b/src/components/chat/home.tsx
@@ -9,11 +9,11 @@ import { AdSenseSlot } from "@/components/adsense-slot";
 import { ChatComposer, type ComposerMessage } from "@/components/chat/chat-composer";
 import { ProjectSelect } from "@/components/projects/project-select";
 import { env } from "@/env";
+import { useAvailableModels } from "@/hooks/use-available-models";
 import { useNewChat } from "@/hooks/use-new-chat";
 import {
   defaultModel,
   getPreferredReasoningEffort,
-  models,
   type ReasoningEffort,
 } from "@/lib/constants";
 import { trpc } from "@/lib/trpc/react";
@@ -66,6 +66,7 @@ export default function ChatHome() {
   const t = useExtracted();
   const { push } = useRouter();
   const startNewChat = useNewChat();
+  const { availableModels } = useAvailableModels();
   const [input, setInput] = useState("");
   const [model, setModel] = useState(defaultModel.value);
   const [webSearch, setWebSearch] = useState(false);
@@ -80,6 +81,12 @@ export default function ChatHome() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const projectsQuery = trpc.projects.list.useQuery();
+  const selectedModel = availableModels.find((entry) => entry.value === model);
+
+  // Fall back when the current selection is not allowed on this plan.
+  if (!selectedModel && availableModels.length > 0) {
+    setModel(availableModels[0].value);
+  }
 
   const handleSubmit = (
     message: ComposerMessage,
@@ -130,7 +137,7 @@ export default function ChatHome() {
 
   const handleModelChange = (value: string) => {
     setModel(value);
-    const nextModel = models.find((entry) => entry.value === value);
+    const nextModel = availableModels.find((entry) => entry.value === value);
     if (!nextModel?.supportsProMode) {
       setProMode(false);
     }

--- a/src/hooks/use-available-models.ts
+++ b/src/hooks/use-available-models.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import type { ModelOption } from "@/components/chat/chat-composer";
 import { authClient } from "@/lib/auth-client";
-import { models } from "@/lib/constants";
+import { getModelsForPlanTier } from "@/lib/constants";
 import { trpc } from "@/lib/trpc/react";
+import { liveUsageQueryOptions } from "@/lib/usage-query-options";
 
 type ProviderSetting = {
   provider: string;
@@ -14,14 +15,22 @@ export function useAvailableModels() {
   const session = authClient.useSession();
   const isAnonymous = Boolean(session.data?.user?.isAnonymous);
 
+  // Default to free until tier is known so free users never briefly see paid models.
+  // Share options with useUsageStatus so both hooks hit the same cached query.
+  const usageQuery = trpc.billing.usage.useQuery(undefined, {
+    ...liveUsageQueryOptions,
+    enabled: Boolean(session.data?.user) && !isAnonymous,
+  });
+  const planTier = isAnonymous ? "free" : (usageQuery.data?.tier ?? "free");
+
   const providersQuery = trpc.providers.getConfig.useQuery(undefined, {
     refetchOnWindowFocus: false,
     staleTime: 30000,
   });
 
   const availableModels = useMemo<ModelOption[]>(() => {
-    return isAnonymous ? models.filter((entry) => !entry.premium) : [...models];
-  }, [isAnonymous]);
+    return getModelsForPlanTier(planTier);
+  }, [planTier]);
 
   const providerSettings = useMemo(() => {
     return new Map<string, ProviderSetting>(
@@ -39,5 +48,6 @@ export function useAvailableModels() {
     providerKeys,
     providersQuery,
     isAnonymous,
+    planTier,
   };
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,21 +22,22 @@ import { PasswordResetEmail, passwordResetEmailSubject } from "@/emails/password
 import { VerificationEmail, verificationEmailSubject } from "@/emails/verification-email";
 import { env } from "@/env";
 import { isEmailConfigured, sendEmail } from "@/lib/email";
-import { isAllowedSignupEmail } from "@/lib/email-domain-policy";
+import {
+  checkSignupEmail,
+  signupEmailDenialCode,
+  signupEmailDenialMessage,
+} from "@/lib/email-domain-policy";
 import { cancelPersonalSubscription, updateTeamSeatCount } from "@/lib/team-billing";
 
 const emailEnabled = isEmailConfigured();
 
-const EMAIL_DOMAIN_NOT_ALLOWED_MESSAGE =
-  "Please use a major email provider (Gmail, Outlook, iCloud, Proton, etc.) or a restricted educational address (e.g. .edu, .ac.jp, .ac.uk, .edu.au). To request adding another email domain, contact contact@deniai.app.";
-
 function assertAllowedSignupEmail(email: string) {
-  if (!isAllowedSignupEmail(email)) {
-    throw new APIError("BAD_REQUEST", {
-      message: EMAIL_DOMAIN_NOT_ALLOWED_MESSAGE,
-      code: "EMAIL_DOMAIN_NOT_ALLOWED",
-    });
-  }
+  const result = checkSignupEmail(email);
+  if (result.ok) return;
+  throw new APIError("BAD_REQUEST", {
+    message: signupEmailDenialMessage(result.reason),
+    code: signupEmailDenialCode(result.reason),
+  });
 }
 
 export const auth = betterAuth({

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -121,6 +121,7 @@ export const models: readonly ModelDefinition[] = [
     author: "openai",
     description: "Fastest, most affordable GPT-5.6 model for high-volume tasks.",
     featured: true,
+    default: true,
     features: ["reasoning", "fast", "fastest"],
     efforts: ["none", "low", "medium", "high", "xhigh", "max"],
     supportsProMode: true,
@@ -132,7 +133,6 @@ export const models: readonly ModelDefinition[] = [
     author: "openai",
     description: "A new class of intelligence for coding and professional work.",
     featured: true,
-    default: true,
     features: ["smartest", "reasoning", "coding", "fast"],
     efforts: ["none", "low", "medium", "high", "xhigh"],
     tokenMultiplier: 1.5,
@@ -538,6 +538,31 @@ export const models: readonly ModelDefinition[] = [
 ];
 
 export const defaultModel = models.find((model) => model.default === true) ?? models[0];
+
+/**
+ * Models available on the Free plan (and guest sessions).
+ * Paid tiers (Plus / Pro / Max / Team) unlock the full model catalog.
+ */
+export const FREE_PLAN_MODEL_VALUES = [
+  "gpt-5.6-luna",
+  "claude-haiku-4.5",
+  "gemini-3.5-flash",
+] as const;
+
+export type FreePlanModelValue = (typeof FREE_PLAN_MODEL_VALUES)[number];
+
+const freePlanModelSet = new Set<string>(FREE_PLAN_MODEL_VALUES);
+
+export function isFreePlanModel(modelValue: string): boolean {
+  return freePlanModelSet.has(modelValue);
+}
+
+export function getModelsForPlanTier(tier: "free" | "plus" | "pro" | "max" | null | undefined) {
+  if (!tier || tier === "free") {
+    return models.filter((model) => isFreePlanModel(model.value));
+  }
+  return [...models];
+}
 
 // Google Analytics
 export const GA_ID = "G-B5H8G73JTN";

--- a/src/lib/email-domain-policy.ts
+++ b/src/lib/email-domain-policy.ts
@@ -7,17 +7,37 @@
  *     registration** (real schools / universities), not open `.edu.<cc>`
  *     namespaces that are routinely sold as throwaway mail
  *
+ * Extra anti-abuse rules on email-based registration:
+ *  - Gmail / Googlemail must use Google OAuth (aliases share one inbox;
+ *    password/magic-link sign-up cannot prove primary ownership).
+ *  - Microsoft free mail rejects alias-like local parts (`+` tags,
+ *    fragmented dots) used by bot farms.
+ *
  * OAuth (Google / GitHub) is not gated by this module — those identities
  * are already provider-verified. Apply only on email-based registration
  * paths (see auth.ts).
  */
 
-/** Exact domains allowed for email/password and magic-link sign-up. */
-export const ALLOWED_EMAIL_PROVIDERS: ReadonlySet<string> = new Set([
-  // Google
+/** Google consumer mail — email/password and magic-link sign-up forbidden. */
+export const GOOGLE_MAIL_DOMAINS: ReadonlySet<string> = new Set([
   "gmail.com",
   "googlemail.com",
-  // Microsoft
+]);
+
+/** Microsoft free consumer mail — alias-like local parts rejected. */
+export const MICROSOFT_MAIL_DOMAINS: ReadonlySet<string> = new Set([
+  "outlook.com",
+  "outlook.jp",
+  "hotmail.com",
+  "hotmail.co.jp",
+  "live.com",
+  "live.jp",
+  "msn.com",
+]);
+
+/** Exact domains allowed for email/password and magic-link sign-up. */
+export const ALLOWED_EMAIL_PROVIDERS: ReadonlySet<string> = new Set([
+  // Microsoft (primary address only — see alias checks)
   "outlook.com",
   "outlook.jp",
   "hotmail.com",
@@ -145,6 +165,15 @@ export function extractEmailDomain(email: string): string | null {
   return domain;
 }
 
+export function extractEmailLocalPart(email: string): string | null {
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf("@");
+  if (at <= 0) return null;
+  const local = trimmed.slice(0, at);
+  if (!local || local.includes(" ")) return null;
+  return local;
+}
+
 function domainMatchesSuffix(domain: string, suffix: string): boolean {
   return domain === suffix || domain.endsWith(`.${suffix}`);
 }
@@ -165,28 +194,122 @@ export function isAllowedEducationalDomain(domain: string): boolean {
   return ALLOWED_EDU_DOMAIN_SUFFIXES.some((suffix) => domainMatchesSuffix(d, suffix));
 }
 
+export function isGoogleMailDomain(domain: string): boolean {
+  return GOOGLE_MAIL_DOMAINS.has(domain.toLowerCase());
+}
+
+export function isMicrosoftMailDomain(domain: string): boolean {
+  return MICROSOFT_MAIL_DOMAINS.has(domain.toLowerCase());
+}
+
 export function isAllowedEmailProviderDomain(domain: string): boolean {
   return ALLOWED_EMAIL_PROVIDERS.has(domain.toLowerCase());
 }
 
-/** True when the email may be used for email/password or magic-link sign-up. */
-export function isAllowedSignupEmail(email: string): boolean {
-  const domain = extractEmailDomain(email);
-  if (!domain) return false;
-  if (isAllowedEmailProviderDomain(domain)) return true;
-  if (isAllowedEducationalDomain(domain)) return true;
+/**
+ * Microsoft free-mail alias / bot-farm local-part heuristics.
+ *
+ * Blocks:
+ *  - plus addressing (`user+tag@outlook.com`)
+ *  - fragmented dots (`e.l.adu.v.a.r.61.5@…`, `a.b.c.d@…`)
+ *  - consecutive dots / empty segments
+ *  - random alnum farm blobs (`muxjcx87394v@outlook.com`)
+ *
+ * Allows normal names: `john.doe@outlook.com`, `jane_smith@hotmail.com`.
+ */
+export function isMicrosoftAliasLikeLocalPart(local: string): boolean {
+  const l = local.trim().toLowerCase();
+  if (!l) return true;
+
+  // Plus aliases (and the random +tag farm).
+  if (l.includes("+")) return true;
+
+  // Empty segments / leading / trailing dots.
+  if (l.startsWith(".") || l.endsWith(".") || l.includes("..")) return true;
+
+  const segments = l.split(".");
+  const dotCount = segments.length - 1;
+
+  // Many dots are almost never a real primary mailbox name.
+  if (dotCount >= 3) return true;
+
+  // Three or more single-character segments → fragmented alias style.
+  const singleCharSegments = segments.filter((segment) => segment.length === 1).length;
+  if (singleCharSegments >= 3) return true;
+
+  // Random-looking local: letters + digit run, no separators
+  // e.g. muxjcx87394v, zayaalaina6874
+  if (/^[a-z]{4,14}\d{3,8}[a-z]{0,3}$/i.test(l) && !l.includes(".") && !l.includes("_")) {
+    return true;
+  }
+
   return false;
 }
 
-export type SignupEmailPolicyResult =
-  | { ok: true }
-  | { ok: false; reason: "invalid" | "not_allowed" };
+export type SignupEmailDenyReason =
+  | "invalid"
+  | "not_allowed"
+  | "use_google_oauth"
+  | "alias_not_allowed";
 
+export type SignupEmailPolicyResult = { ok: true } | { ok: false; reason: SignupEmailDenyReason };
+
+/**
+ * Full sign-up policy for email/password and magic-link registration.
+ * Does not apply to OAuth callbacks.
+ */
 export function checkSignupEmail(email: string): SignupEmailPolicyResult {
   const domain = extractEmailDomain(email);
   if (!domain) return { ok: false, reason: "invalid" };
-  if (isAllowedSignupEmail(email)) return { ok: true };
+
+  // Gmail aliases all deliver to one inbox; require Google-verified identity.
+  if (isGoogleMailDomain(domain)) {
+    return { ok: false, reason: "use_google_oauth" };
+  }
+
+  if (isMicrosoftMailDomain(domain)) {
+    const local = extractEmailLocalPart(email);
+    if (!local || isMicrosoftAliasLikeLocalPart(local)) {
+      return { ok: false, reason: "alias_not_allowed" };
+    }
+  }
+
+  if (isAllowedEmailProviderDomain(domain)) return { ok: true };
+  if (isAllowedEducationalDomain(domain)) return { ok: true };
   return { ok: false, reason: "not_allowed" };
+}
+
+/** True when the email may be used for email/password or magic-link sign-up. */
+export function isAllowedSignupEmail(email: string): boolean {
+  return checkSignupEmail(email).ok;
+}
+
+export function signupEmailDenialMessage(reason: SignupEmailDenyReason): string {
+  switch (reason) {
+    case "use_google_oauth":
+      return "Gmail addresses must sign in with Google. Please use the Continue with Google button.";
+    case "alias_not_allowed":
+      return "This Outlook/Hotmail address looks like an alias (plus tags or unusual dots). Please use your primary Microsoft email address.";
+    case "invalid":
+      return "Please enter a valid email address.";
+    case "not_allowed":
+    default:
+      return "Please use a major email provider (Outlook, iCloud, Proton, etc.) or a restricted educational address (e.g. .edu, .ac.jp, .ac.uk, .edu.au). Gmail requires Continue with Google. To request adding another email domain, contact contact@deniai.app.";
+  }
+}
+
+export function signupEmailDenialCode(reason: SignupEmailDenyReason): string {
+  switch (reason) {
+    case "use_google_oauth":
+      return "EMAIL_USE_GOOGLE_OAUTH";
+    case "alias_not_allowed":
+      return "EMAIL_ALIAS_NOT_ALLOWED";
+    case "invalid":
+      return "EMAIL_INVALID";
+    case "not_allowed":
+    default:
+      return "EMAIL_DOMAIN_NOT_ALLOWED";
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Restrict Free plan models to GPT-5.6 Luna, Claude Haiku 4.5, and Gemini 3.5 Flash (UI + API).
- Require Google OAuth for Gmail sign-up; block Microsoft free-mail alias patterns (`+`, fragmented dots, random locals).
- Default model set to GPT-5.6 Luna for Free-plan compatibility.

## Test plan
- [ ] Free / guest users only see the three free models; paid tiers see full catalog.
- [ ] Chat API rejects non-free models for free-tier users.
- [ ] Email sign-up with Gmail shows Google OAuth message.
- [ ] Outlook/Hotmail with `+` or fragmented dots is rejected; primary `john.doe@outlook.com` works.
- [ ] Existing Gmail accounts can still magic-link / password sign-in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added plan-based model availability, including free-tier access to select models.
  - Updated the default model to GPT-5.6 Luna.
  - Chat model selections now reflect currently available options and reset when unavailable.

- **Bug Fixes**
  - Restricted models are now blocked consistently for free and anonymous access, including bring-your-own-key usage.

- **Sign-Up**
  - Added email-domain validation with clearer rejection messages.
  - Google consumer email addresses must use Google OAuth; certain Microsoft aliases are declined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->