### PR TITLE
[codex] fix: include SWC ESM helpers in standalone image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,20 @@ ENV DATABASE_URL=$DATABASE_URL \
 # on some hosts (SIGILL / exit 132).
 RUN node ./node_modules/next/dist/bin/next build
 
+# Next's standalone tracer can copy only the CJS side of Bun's virtual-store
+# @swc/helpers package. Node 22 resolves its `module-sync` condition to ESM,
+# so preserve the ESM files in every traced helper package as well.
+RUN set -eux; \
+  for standalone_helpers in \
+    .next/standalone/node_modules/.bun/*/node_modules/@swc/helpers \
+    .next/standalone/node_modules/@swc/helpers; do \
+    [ -d "$standalone_helpers" ] || continue; \
+    source_helpers="${standalone_helpers#.next/standalone/}"; \
+    [ -d "$source_helpers/esm" ] || continue; \
+    mkdir -p "$standalone_helpers/esm"; \
+    cp -a "$source_helpers/esm/." "$standalone_helpers/esm/"; \
+  done
+
 # ---------------------------------------------------------------------------
 # Runtime (Next.js standalone + Node)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Restore the ESM files for traced `@swc/helpers` packages after the Next.js standalone build.
- Keep the fix in the Docker build stage so the runtime image resolves Node 22's `module-sync` condition correctly.

## Root cause

Bun's virtual-store layout allowed Next's standalone tracer to copy the CJS side of `@swc/helpers` without the ESM files. Node 22 then selected the missing ESM entrypoint at runtime.

## Validation

- `bun run lint`
- `bun run typecheck`
- `node ./node_modules/next/dist/bin/next build`
- Verified `@swc/helpers/_/_interop_require_default` resolves from the generated standalone artifact after the Docker copy step.

A Docker daemon was not available locally, so the image itself was not launched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed standalone production builds on Node.js 22 by ensuring required ESM helper files are included.
  * Improved application startup and runtime compatibility when resolving ESM dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->